### PR TITLE
feat: Button, TextField 컴포넌트 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,5 +44,6 @@ module.exports = {
         endOfLine: 'auto',
       },
     ],
+    'jsx-a11y/no-autofocus': 'off',
   },
 };

--- a/src/components/atoms/button/button.tsx
+++ b/src/components/atoms/button/button.tsx
@@ -1,0 +1,90 @@
+import { ComponentPropsWithoutRef, ReactNode } from 'react';
+import tw, { css } from 'twin.macro';
+import { tailwindColors } from '../../../constants/tailwind';
+import Spinner from '../spinner';
+
+interface ButtonProps
+  extends Omit<ComponentPropsWithoutRef<'button'>, 'color'> {
+  /**
+   * 버튼 내부에 들어갈 내용 입니다.
+   */
+  children: ReactNode;
+
+  /**
+   * 버튼의 사이즈 입니다.
+   */
+  size?: 'small' | 'medium' | 'large';
+
+  /**
+   * 버튼의 색상으로 Tailwind Color에 기반하고 있습니다.
+   */
+  color?: keyof typeof tailwindColors;
+
+  /**
+   * 부모 width의 풀사이즈 버튼으로 사용할 수 있습니다.
+   */
+  fullWidth?: boolean;
+
+  /**
+   * mutate의 로딩 상태를 나타내는 작업 등에 사용할 수 있습니다.
+   */
+  isLoading?: boolean;
+}
+
+const colorStyle = (color: ButtonProps['color']) => {
+  if (!color) {
+    return null;
+  }
+  return [
+    tw`text-white disabled:bg-gray-200 disabled:text-gray-400`,
+    css`
+      background-color: ${tailwindColors[color][500]};
+      &:hover&:not([disabled]) {
+        background-color: ${tailwindColors[color][600]};
+      }
+    `,
+  ];
+};
+
+const sizeStyle = (size: ButtonProps['size']) => {
+  if (!size) {
+    return null;
+  }
+  return {
+    large: tw`px-6 py-1.5 text-lg`,
+    medium: tw`px-5 py-[7px]`,
+    small: tw`px-4 py-[6px] text-sm`,
+  }[size];
+};
+
+/**
+ * 버튼 컴포넌트 입니다.
+ */
+function Button({
+  children,
+  size = 'medium',
+  color = 'blue',
+  fullWidth = false,
+  isLoading = false,
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled || isLoading}
+      css={[
+        tw`flex-center rounded-3xl font-semibold break-all`,
+        colorStyle(color),
+        sizeStyle(size),
+        fullWidth && tw`w-full`,
+      ]}
+      type="button"
+      {...props}
+    >
+      {isLoading && <Spinner size={size === 'small' ? 14 : 16} tw="mr-1.5" />}
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/src/components/atoms/button/index.stories.tsx
+++ b/src/components/atoms/button/index.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { tailwindColors } from '../../../constants/tailwind';
+import Button from './index';
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  argTypes: {
+    color: {
+      options: Object.keys(tailwindColors),
+      control: { type: 'select' },
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+    size: {
+      table: {
+        type: {
+          summary: 'small | medium | large',
+        },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-60 flex-center">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: '회원가입',
+    color: 'blue',
+    size: 'medium',
+    fullWidth: false,
+    isLoading: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    ...Default.args,
+    isLoading: true,
+  },
+};

--- a/src/components/atoms/button/index.ts
+++ b/src/components/atoms/button/index.ts
@@ -1,0 +1,3 @@
+import Button from './button';
+
+export default Button;

--- a/src/components/atoms/text-field/index.stories.tsx
+++ b/src/components/atoms/text-field/index.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useState } from 'react';
+import TextField from './index';
+
+const meta = {
+  component: TextField,
+  argTypes: {
+    value: {
+      control: {
+        disable: true,
+      },
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+    onChange: {
+      table: {
+        type: {
+          summary: '(event) => {}',
+        },
+      },
+      control: {
+        disable: true,
+      },
+    },
+    type: {
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+  },
+} satisfies Meta<typeof TextField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: undefined,
+    onChange: () => {},
+    label: '닉네임',
+    autoFocus: false,
+    disabled: false,
+    hasError: false,
+    errorMessages: [],
+    type: 'text',
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState<string>('셀럽픽');
+
+    return (
+      <TextField
+        {...args}
+        value={value}
+        onChange={(event) => {
+          setValue(event.target.value);
+        }}
+      />
+    );
+  },
+};
+
+export const Password: Story = {
+  args: {
+    ...Default.args,
+    label: '비밀번호',
+    type: 'password',
+  },
+  render: Default.render,
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
+  render: Default.render,
+};
+
+export const HasError: Story = {
+  args: {
+    ...Default.args,
+    errorMessages: ['이미 존재하는 닉네임 입니다.', '그 외 에러 메세지'],
+  },
+  render: Default.render,
+};

--- a/src/components/atoms/text-field/index.ts
+++ b/src/components/atoms/text-field/index.ts
@@ -1,0 +1,3 @@
+import TextField from './text-field';
+
+export default TextField;

--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -55,7 +55,7 @@ export interface TextFieldProps {
 /**
  * 라벨, 에러 메세지 등을 포함하고 있는 Input 컴포넌트 입니다.
  */
-export const TextField = forwardRef(function TextField(
+const TextField = forwardRef(function TextField(
   props: TextFieldProps,
   ref: ForwardedRef<HTMLInputElement>
 ) {

--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -6,15 +6,55 @@ import { isEmptyArray } from '../../../utils/array';
 type InputProps = ComponentPropsWithRef<'input'>;
 
 export interface TextFieldProps {
+  /**
+   * 컴포넌트의 value값 입니다.
+   */
   value: InputProps['value'];
+
+  /**
+   * 컴포넌트의 value값이 변할 때 실행 되는 콜백 함수 입니다.
+   */
   onChange: InputProps['onChange'];
+
+  /**
+   * `text`, `email` 등 타입을 지정할 수 있습니다.
+   */
   type?: InputProps['type'];
+
+  /**
+   * 마운트시 포커스 여부를 정할 수 있습니다.
+   */
+  autoFocus?: boolean;
+
+  /**
+   * 라벨 텍스트 입니다.
+   */
   label: string;
+
+  /**
+   * `disabled` 상태를 나타낼 수 있습니다.
+   */
+  disabled?: boolean;
+
+  /**
+   * 에러 상태를 나타낼 수 있습니다.
+   */
   hasError?: boolean;
+
+  /**
+   * 컴포넌트 하단에 에러 메세지를 표시할 수 있습니다.
+   */
   errorMessages?: Array<string>;
+
+  /**
+   * 컴포넌트의 Wrapper 스타일을 지정할 수 있습니다.
+   */
   className?: string;
 }
 
+/**
+ * 라벨, 에러 메세지 등을 포함하고 있는 Input 컴포넌트 입니다.
+ */
 export const TextField = forwardRef(function TextField(
   props: TextFieldProps,
   ref: ForwardedRef<HTMLInputElement>

--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -1,0 +1,72 @@
+import clsx from 'clsx';
+import { ComponentPropsWithRef, ForwardedRef, forwardRef, useId } from 'react';
+import tw from 'twin.macro';
+import { isEmptyArray } from '../../../utils/array';
+
+type InputProps = ComponentPropsWithRef<'input'>;
+
+export interface TextFieldProps {
+  value: InputProps['value'];
+  onChange: InputProps['onChange'];
+  type?: InputProps['type'];
+  label: string;
+  hasError?: boolean;
+  errorMessages?: Array<string>;
+  className?: string;
+}
+
+export const TextField = forwardRef(function TextField(
+  props: TextFieldProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
+  const {
+    value,
+    onChange,
+    type = 'text',
+    autoFocus = false,
+    label,
+    disabled,
+    hasError = false,
+    errorMessages = [],
+    className,
+  } = props;
+
+  const inputId = useId();
+  const error = hasError || !isEmptyArray(errorMessages);
+
+  return (
+    <div className={clsx('flex flex-col gap-y-2', className)}>
+      <label
+        htmlFor={inputId}
+        css={[
+          tw`flex flex-col gap-y-0.5 px-2.5 py-1 border border-solid border-gray-400 rounded`,
+          !disabled &&
+            tw`cursor-text focus-within:shadow-sm focus-within:shadow-gray-300`,
+          disabled && tw`bg-gray-100 [&>input]:bg-gray-100`,
+          error && tw`border-red-500 [&>span]:text-red-500`,
+        ]}
+      >
+        <span css={[tw`text-gray-500 text-sm`]}>{label}</span>
+        <input
+          ref={ref}
+          id={inputId}
+          type={type}
+          autoFocus={autoFocus}
+          value={value || ''}
+          onChange={onChange}
+          disabled={disabled}
+          css={[tw`w-full outline-0`]}
+        />
+      </label>
+      <ul css={[tw`ml-1`]}>
+        {errorMessages.map((message) => (
+          <li key={message} css={[tw`text-red-500 text-sm`]}>
+            {message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+});
+
+export default TextField;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,3 @@
+export const isEmptyArray = <T>(arr: Array<T>) => {
+  return arr.length < 1;
+};


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 공통 컴포넌트인 `Button`, `TextField` 컴포넌트를 구현 했습니다.

### PR Point
- `forwardRef`로 래핑한 컴포넌트의 JSDocs를 스토리북의 `docgen`이 읽어들이지 못하는 문제가 있었는데, `forwardRef<ElementType, PropsType>`이 아닌 `function TextField(
  props: PropsType,
  ref: ForwardedRef<ElementType>
)`과 같이 작성 하였더니 문제를 해결할 수 있었습니다.

closed #34 
