### PR TITLE
feat: 로그인 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/serialize": "^1.3.0",
+    "@hookform/resolvers": "^3.9.0",
     "@storybook/preview-api": "8.2.6",
     "@tanstack/react-query": "^5.51.23",
     "@tanstack/react-query-devtools": "^5.51.23",
@@ -28,12 +29,14 @@
     "lodash.omit": "^4.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.52.2",
     "react-intersection-observer": "^9.13.0",
     "react-router-dom": "^6.26.0",
     "react-transition-group": "^4.4.5",
     "storybook-addon-react-router-v6": "^2.0.15",
     "swiper": "^11.1.9",
-    "use-query-params": "^2.2.1"
+    "use-query-params": "^2.2.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.24.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/serialize':
         specifier: ^1.3.0
         version: 1.3.0
+      '@hookform/resolvers':
+        specifier: ^3.9.0
+        version: 3.9.0(react-hook-form@7.52.2(react@18.3.1))
       '@storybook/preview-api':
         specifier: 8.2.6
         version: 8.2.6(storybook@8.2.6(@babel/preset-env@7.25.0(@babel/core@7.24.9)))
@@ -41,6 +44,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.52.2
+        version: 7.52.2(react@18.3.1)
       react-intersection-observer:
         specifier: ^9.13.0
         version: 9.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -59,6 +65,9 @@ importers:
       use-query-params:
         specifier: ^2.2.1
         version: 2.2.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.26.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@babel/preset-react':
         specifier: ^7.24.7
@@ -1098,6 +1107,11 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@hookform/resolvers@3.9.0':
+    resolution: {integrity: sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -3681,6 +3695,12 @@ packages:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
       react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
 
+  react-hook-form@7.52.2:
+    resolution: {integrity: sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-inspector@6.0.2:
     resolution: {integrity: sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==}
     peerDependencies:
@@ -4402,6 +4422,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -5528,6 +5551,10 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.0': {}
+
+  '@hookform/resolvers@3.9.0(react-hook-form@7.52.2(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.52.2(react@18.3.1)
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -8422,6 +8449,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.1.0
 
+  react-hook-form@7.52.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-inspector@6.0.2(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -9247,3 +9278,5 @@ snapshots:
   yaml@2.5.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,6 @@
+import { axiosInstance } from '../config/axios';
+import { AuthStatusResponse } from '../types/auth';
+
+export const fetchAuthStatus = async () => {
+  return (await axiosInstance.get<AuthStatusResponse>('/auth/status')).data;
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,10 @@
 import { axiosInstance } from '../config/axios';
-import { AuthStatusResponse } from '../types/auth';
+import { AuthStatusResponse, LoginRequest } from '../types/auth';
 
 export const fetchAuthStatus = async () => {
   return (await axiosInstance.get<AuthStatusResponse>('/auth/status')).data;
+};
+
+export const login = async ({ payload }: LoginRequest) => {
+  await axiosInstance.post('/login/', payload);
 };

--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -75,7 +75,7 @@ const TextField = forwardRef(function TextField(
   const error = hasError || !isEmptyArray(errorMessages);
 
   return (
-    <div className={clsx('flex flex-col gap-y-2', className)}>
+    <div className={clsx('flex w-full flex-col gap-y-2', className)}>
       <label
         htmlFor={inputId}
         css={[

--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -44,7 +44,7 @@ export interface TextFieldProps {
   /**
    * 컴포넌트 하단에 에러 메세지를 표시할 수 있습니다.
    */
-  errorMessages?: Array<string>;
+  errorMessages?: Array<string | undefined | null>;
 
   /**
    * 컴포넌트의 Wrapper 스타일을 지정할 수 있습니다.
@@ -70,9 +70,10 @@ const TextField = forwardRef(function TextField(
     errorMessages = [],
     className,
   } = props;
-
   const inputId = useId();
-  const error = hasError || !isEmptyArray(errorMessages);
+
+  const filteredErrorMessages = errorMessages.filter((message) => !!message);
+  const error = hasError || !isEmptyArray(filteredErrorMessages);
 
   return (
     <div className={clsx('flex w-full flex-col gap-y-2', className)}>
@@ -99,7 +100,7 @@ const TextField = forwardRef(function TextField(
         />
       </label>
       <ul css={[tw`ml-1`]}>
-        {errorMessages.map((message) => (
+        {filteredErrorMessages.map((message) => (
           <li key={message} css={[tw`text-red-500 text-sm`]}>
             {message}
           </li>

--- a/src/components/common/layout/bottom-tab-bar.tsx
+++ b/src/components/common/layout/bottom-tab-bar.tsx
@@ -1,6 +1,7 @@
 import { cloneElement, ComponentPropsWithoutRef, ReactElement } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import tw from 'twin.macro';
+import useAuthStatus from '../../../hooks/useAuthStatus';
 import MaterialSymbol from '../../atoms/material-symbol';
 
 interface TabNavigatorProps {
@@ -36,6 +37,8 @@ const layoutStyle = tw`
 `;
 
 function BottomTabBar() {
+  const { isAuthenticated } = useAuthStatus();
+
   return (
     <div css={[layoutStyle, tw`flex-y-center justify-around`]}>
       <TabNavigator
@@ -61,7 +64,8 @@ function BottomTabBar() {
       <TabNavigator
         icon={<MaterialSymbol name="person" size={29} wght={300} />}
         label="마이"
-        to=""
+        // TODO: 로그인시 '/users/me' 내 프로필 페이지로 라우팅
+        to={isAuthenticated ? '' : '/login'}
       />
     </div>
   );

--- a/src/components/common/layout/layout.tsx
+++ b/src/components/common/layout/layout.tsx
@@ -5,11 +5,7 @@ import BottomTabBar from './bottom-tab-bar';
 
 function Layout() {
   return (
-    <div
-      css={[
-        tw`max-w-[--layout-max-width] min-w-[--layout-min-width] w-full min-h-[100vh] mx-auto border-solid border-x-2 border-gray-100`,
-      ]}
-    >
+    <div className="layout-container">
       <AppBar />
       <div css={[tw`pb-[--bottom-tab-bar-height]`]}>
         <Outlet />

--- a/src/hooks/mutations/useLogin.ts
+++ b/src/hooks/mutations/useLogin.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { login } from '../../api/auth';
+import { LoginRequest } from '../../types/auth';
+
+const useLogin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (req: LoginRequest) => login(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['fetchAuthStatus'] });
+    },
+  });
+};
+
+export default useLogin;

--- a/src/hooks/mutations/useLogin.ts
+++ b/src/hooks/mutations/useLogin.ts
@@ -1,14 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { login } from '../../api/auth';
 import { LoginRequest } from '../../types/auth';
 
 const useLogin = () => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   return useMutation({
     mutationFn: (req: LoginRequest) => login(req),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchAuthStatus'] });
+      // TODO: 내 프로필 페이지로 이동하게 변경
+      navigate('/');
     },
   });
 };

--- a/src/hooks/queries/useFetchAuthStatus.ts
+++ b/src/hooks/queries/useFetchAuthStatus.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchAuthStatus } from '../../api/auth';
+
+const useFetchAuthStatus = () => {
+  return useQuery({
+    queryKey: ['fetchAuthStatus'],
+    queryFn: fetchAuthStatus,
+  });
+};
+
+export default useFetchAuthStatus;

--- a/src/hooks/useAuthStatus.ts
+++ b/src/hooks/useAuthStatus.ts
@@ -1,0 +1,10 @@
+import useFetchAuthStatus from './queries/useFetchAuthStatus';
+
+const useAuthStatus = () => {
+  const { data } = useFetchAuthStatus();
+  const isAuthenticated = !!data?.isAuthenticated;
+
+  return { isAuthenticated };
+};
+
+export default useAuthStatus;

--- a/src/hooks/useServerErrorResponse.ts
+++ b/src/hooks/useServerErrorResponse.ts
@@ -1,0 +1,11 @@
+import { isAxiosError } from 'axios';
+
+const useServerErrorResponse = <ErrorResponseType>(error: Error | null) => {
+  if (!isAxiosError<ErrorResponseType>(error) || !error.response) {
+    return undefined;
+  }
+
+  return error.response;
+};
+
+export default useServerErrorResponse;

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,9 @@
   --layout-min-width: 350px;
   --bottom-tab-bar-height: calc(70px + env(safe-area-inset-bottom));
 }
+
+@layer components {
+  .layout-container {
+    @apply mx-auto min-h-[100vh] w-full min-w-[--layout-min-width] max-w-[--layout-max-width] border-x-2 border-solid border-gray-100;
+  }
+}

--- a/src/pages/login/index.ts
+++ b/src/pages/login/index.ts
@@ -1,0 +1,3 @@
+import LoginPage from './login';
+
+export default LoginPage;

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,5 +1,50 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import tw from 'twin.macro';
+import Button from '../../components/atoms/button';
+import TextField from '../../components/atoms/text-field';
+
 function LoginPage() {
-  return <div> </div>;
+  const [email, setEmail] = useState<string>();
+  const [password, setPassword] = useState<string>();
+
+  return (
+    <div className="layout-container flex-center">
+      <form css={[tw`flex-center flex-col w-72`]}>
+        <span css={[tw`font-bold text-4xl mb-16`]}>celeb pick</span>
+        <TextField
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          type="email"
+          label="이메일"
+          autoFocus
+          css={[tw`mb-1.5`]}
+        />
+        <TextField
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          type="password"
+          label="비밀번호"
+          css={[tw`mb-1`]}
+        />
+        <Link
+          to="/"
+          css={[tw`ml-auto mb-10 text-blue-500 text-sm font-medium`]}
+        >
+          게스트로 이용하기
+        </Link>
+        <Button type="submit" fullWidth css={[tw`mb-8`]}>
+          로그인
+        </Button>
+        <p css={[tw`font-medium`]}>
+          계정이 없으신가요? &nbsp;
+          <Link to="/signup" css={[tw`text-blue-700`]}>
+            가입하기
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
 }
 
 export default LoginPage;

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,0 +1,5 @@
+function LoginPage() {
+  return <div> </div>;
+}
+
+export default LoginPage;

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,31 +1,45 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import tw from 'twin.macro';
 import Button from '../../components/atoms/button';
 import TextField from '../../components/atoms/text-field';
+import useLogin from '../../hooks/mutations/useLogin';
+import useServerErrorResponse from '../../hooks/useServerErrorResponse';
+import { LoginErrorResponse } from '../../types/auth';
+import useLoginForm from './useLoginForm';
 
 function LoginPage() {
-  const [email, setEmail] = useState<string>();
-  const [password, setPassword] = useState<string>();
+  const loginForm = useLoginForm();
+  const { mutate, error, isPending } = useLogin();
+  const serverError = useServerErrorResponse<LoginErrorResponse>(error);
 
   return (
     <div className="layout-container flex-center">
-      <form css={[tw`flex-center flex-col w-72`]}>
+      <form
+        onSubmit={loginForm.handleSubmit((payload) => mutate({ payload }))}
+        css={[tw`flex-center flex-col w-72`]}
+      >
         <span css={[tw`font-bold text-4xl mb-16`]}>celeb pick</span>
         <TextField
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
           type="email"
           label="이메일"
+          value={loginForm.email.value}
+          onChange={loginForm.email.onChange}
+          hasError={!!error}
+          errorMessages={[loginForm.errors.email?.message]}
           autoFocus
           css={[tw`mb-1.5`]}
         />
         <TextField
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
           type="password"
           label="비밀번호"
+          value={loginForm.password.value}
+          onChange={loginForm.password.onChange}
           css={[tw`mb-1`]}
+          hasError={!!error}
+          errorMessages={[
+            loginForm.errors.password?.message,
+            serverError?.data.message,
+          ]}
         />
         <Link
           to="/"
@@ -33,7 +47,7 @@ function LoginPage() {
         >
           게스트로 이용하기
         </Link>
-        <Button type="submit" fullWidth css={[tw`mb-8`]}>
+        <Button type="submit" isLoading={isPending} fullWidth css={[tw`mb-8`]}>
           로그인
         </Button>
         <p css={[tw`font-medium`]}>

--- a/src/pages/login/useLoginForm.ts
+++ b/src/pages/login/useLoginForm.ts
@@ -1,0 +1,39 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useController, useForm } from 'react-hook-form';
+import { z, ZodType } from 'zod';
+import { LoginRequest } from '../../types/auth';
+
+const schema = z.object({
+  email: z
+    .string()
+    .min(1, { message: '이메일을 입력해 주세요.' })
+    .email('이메일 형식에 맞게 입력해 주세요.'),
+  password: z
+    .string()
+    .min(1, '비밀번호를 입력해 주세요.')
+    .min(8, '비밀번호는 8자 이상이어야 합니다.'),
+}) satisfies ZodType<LoginRequest['payload']>;
+
+const useLoginForm = () => {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginRequest['payload']>({ resolver: zodResolver(schema) });
+
+  const { field: email } = useController({
+    name: 'email',
+    defaultValue: '',
+    control,
+  });
+
+  const { field: password } = useController({
+    name: 'password',
+    defaultValue: '',
+    control,
+  });
+
+  return { handleSubmit, errors, email, password };
+};
+
+export default useLoginForm;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -20,11 +20,11 @@ const router: Router = createBrowserRouter([
         path: '/',
         element: <HomePage />,
       },
-      {
-        path: '/login',
-        element: <LoginPage />,
-      },
     ],
+  },
+  {
+    path: '/login',
+    element: <LoginPage />,
   },
 ]);
 

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,6 +3,7 @@ import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import Layout from '../components/common/layout/layout';
 import HomePage from '../pages/home';
+import LoginPage from '../pages/login';
 
 type Router = ReturnType<typeof createBrowserRouter>;
 
@@ -18,6 +19,10 @@ const router: Router = createBrowserRouter([
       {
         path: '/',
         element: <HomePage />,
+      },
+      {
+        path: '/login',
+        element: <LoginPage />,
       },
     ],
   },

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,14 @@
 export interface AuthStatusResponse {
   isAuthenticated: boolean;
 }
+
+export interface LoginRequest {
+  payload: {
+    email: string;
+    password: string;
+  };
+}
+
+export interface LoginErrorResponse {
+  message: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,3 @@
+export interface AuthStatusResponse {
+  isAuthenticated: boolean;
+}


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 로그인 상태 조회 API를 연동
- `BottomTabBar` "마이탭"을 로그인 페이지와 페이지 연동
- 로그인 페이지 마크업
- 로그인 유효성 검사
- 로그인 API 연동
- TextField default width 100%로 변경, 에러 메세지 undefined 허용

### PR Point
- 로그인 성공시 내 프로필로 이동하는게 UX상 좋지만, 내 프로필 페이지가 미구현 되어 홈 페이지로 라우팅하게 구현 했습니다.

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/2ff67778-9d54-4cfe-9fe8-22b2efcb7c99)

closed #33
