### PR TITLE
fix: input이 TextField의 전체 영역을 차지하도록 CSS 수정

### DIFF
--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -80,7 +80,7 @@ const TextField = forwardRef(function TextField(
       <label
         htmlFor={inputId}
         css={[
-          tw`relative flex flex-col gap-y-0.5 border border-solid border-gray-400 rounded`,
+          tw`relative border border-solid border-gray-400 rounded`,
           !disabled &&
             tw`cursor-text focus-within:shadow-sm focus-within:shadow-gray-300`,
           disabled && tw`bg-gray-100 [&>input]:bg-gray-100`,

--- a/src/components/atoms/text-field/text-field.tsx
+++ b/src/components/atoms/text-field/text-field.tsx
@@ -80,14 +80,16 @@ const TextField = forwardRef(function TextField(
       <label
         htmlFor={inputId}
         css={[
-          tw`flex flex-col gap-y-0.5 px-2.5 py-1 border border-solid border-gray-400 rounded`,
+          tw`relative flex flex-col gap-y-0.5 border border-solid border-gray-400 rounded`,
           !disabled &&
             tw`cursor-text focus-within:shadow-sm focus-within:shadow-gray-300`,
           disabled && tw`bg-gray-100 [&>input]:bg-gray-100`,
           error && tw`border-red-500 [&>span]:text-red-500`,
         ]}
       >
-        <span css={[tw`text-gray-500 text-sm`]}>{label}</span>
+        <span css={[tw`absolute top-1 left-[10px]  text-gray-500 text-sm`]}>
+          {label}
+        </span>
         <input
           ref={ref}
           id={inputId}
@@ -96,7 +98,10 @@ const TextField = forwardRef(function TextField(
           value={value || ''}
           onChange={onChange}
           disabled={disabled}
-          css={[tw`w-full outline-0`]}
+          css={[
+            tw`w-full px-2.5 pt-6 pb-1 outline-0`,
+            { borderRadius: 'inherit' },
+          ]}
         />
       </label>
       {error && (


### PR DESCRIPTION
# Pull Request
### 작업한 내용
> 자동입력으로 선택 됐을때 일정부분만 하이라이팅되는 UI문제를 CSS 수정을 통해 해결 했습니다.

![image](https://github.com/user-attachments/assets/028d59b1-5ce2-47ab-b9f5-732789b9a9fd)

### 📸 스크린샷
- 수정 전(input이 일부만 차지)

![image](https://github.com/user-attachments/assets/f565f3ce-ca4f-4201-9537-b9a15c5d00d8)


- 수정 후(input이 TextField의 전체 영역을 차지)

![image](https://github.com/user-attachments/assets/548bbecb-3767-4751-b4f7-33136b0d11e3)

closed #38
