### PR TITLE
feat: 에러 바운더리 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash.omit": "^4.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^4.0.13",
     "react-hook-form": "^7.52.2",
     "react-intersection-observer": "^9.13.0",
     "react-router-dom": "^6.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-error-boundary:
+        specifier: ^4.0.13
+        version: 4.0.13(react@18.3.1)
       react-hook-form:
         specifier: ^7.52.2
         version: 7.52.2(react@18.3.1)
@@ -3930,6 +3933,11 @@ packages:
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
       react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+
+  react-error-boundary@4.0.13:
+    resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-hook-form@7.52.2:
     resolution: {integrity: sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==}
@@ -8973,6 +8981,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.1.0
+
+  react-error-boundary@4.0.13(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.25.0
+      react: 18.3.1
 
   react-hook-form@7.52.2(react@18.3.1):
     dependencies:

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,0 +1,15 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from './config/tanstack-query';
+import Router from './router';
+
+function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Router />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+
+export default App;

--- a/src/components/common/layout/layout.tsx
+++ b/src/components/common/layout/layout.tsx
@@ -22,7 +22,7 @@ function Layout({ children, ...props }: LayoutProps) {
   return (
     <div
       css={[
-        tw`mx-auto min-h-[100vh] w-full min-w-[--layout-min-width] max-w-[--layout-max-width] border-x-2 border-solid border-gray-100`,
+        tw`flex flex-col min-h-[100vh] w-full min-w-[--layout-min-width] max-w-[--layout-max-width] mx-auto border-x-2 border-solid border-gray-100`,
       ]}
       {...props}
     >

--- a/src/components/errors/api-error-boundary/api-error-boundary.tsx
+++ b/src/components/errors/api-error-boundary/api-error-boundary.tsx
@@ -1,0 +1,53 @@
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { useLocation } from 'react-router-dom';
+
+import { HttpStatusCode, isAxiosError } from 'axios';
+import { generateServerErrorMessage } from '../../../utils/error';
+import Layout from '../../common/layout';
+import LogoAppBar from '../../common/layout/logo-app-bar';
+import ErrorSection from '../error-section';
+
+interface ApiErrorBoundaryProps {
+  children: ReactNode;
+}
+
+function FallbackComponent({ error, resetErrorBoundary }: FallbackProps) {
+  if (!isAxiosError(error)) {
+    throw error;
+  }
+
+  if (error.response?.status === HttpStatusCode.Unauthorized) {
+    window.location.href = '/login';
+    return null;
+  }
+
+  return (
+    <Layout>
+      <LogoAppBar />
+      <ErrorSection
+        title={generateServerErrorMessage(error)}
+        subTittle="조금 뒤 다시 시도해 주세요."
+        resetErrorBoundary={resetErrorBoundary}
+      />
+    </Layout>
+  );
+}
+
+function ApiErrorBoundary({ children }: ApiErrorBoundaryProps) {
+  const { reset } = useQueryErrorResetBoundary();
+  const { key } = useLocation();
+
+  return (
+    <ErrorBoundary
+      FallbackComponent={FallbackComponent}
+      onReset={reset}
+      resetKeys={[key]}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export default ApiErrorBoundary;

--- a/src/components/errors/api-error-boundary/index.ts
+++ b/src/components/errors/api-error-boundary/index.ts
@@ -1,0 +1,3 @@
+import ApiErrorBoundary from './api-error-boundary';
+
+export default ApiErrorBoundary;

--- a/src/components/errors/error-section/error-section.tsx
+++ b/src/components/errors/error-section/error-section.tsx
@@ -1,0 +1,50 @@
+import ErrorOutlineRoundedIcon from '@mui/icons-material/ErrorOutlineRounded';
+import { FallbackProps } from 'react-error-boundary';
+import tw from 'twin.macro';
+import Button from '../../atoms/button';
+
+interface ErrorSectionProps {
+  /**
+   * 에러 메세지 타이틀 입니다.
+   */
+  title: string;
+
+  /**
+   * 에러 메세지 서브 타이틀 입니다.
+   */
+  subTittle?: string;
+
+  /**
+   * ErrorBoundary Reset Callback 함수 입니다.
+   */
+  resetErrorBoundary?: FallbackProps['resetErrorBoundary'];
+
+  className?: string;
+}
+
+/**
+ * `ErrorBoundary`의 Fallback에 사용되는 컴포넌트 입니다.
+ */
+function ErrorSection({
+  title,
+  subTittle,
+  resetErrorBoundary,
+  className,
+}: ErrorSectionProps) {
+  return (
+    <div css={[tw`flex-center flex-col flex-1 h-full`]} className={className}>
+      <ErrorOutlineRoundedIcon fontSize="large" css={[tw`text-red-500 mb-4`]} />
+      <h1 css={[tw`text-xl font-semibold`]}>{title}</h1>
+      {!!subTittle && (
+        <p css={[tw`font-medium text-gray-400 mt-2`]}>{subTittle}</p>
+      )}
+      {!!resetErrorBoundary && (
+        <Button color="slate" onClick={resetErrorBoundary} css={[tw`mt-7`]}>
+          다시 시도
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export default ErrorSection;

--- a/src/components/errors/error-section/index.stories.tsx
+++ b/src/components/errors/error-section/index.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import tw from 'twin.macro';
+import ErrorSection from './index';
+
+const meta: Meta<typeof ErrorSection> = {
+  component: ErrorSection,
+  decorators: [
+    (Story) => (
+      <div css={[tw`border-solid border w-96 h-[600px]`]}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: '잠시 연결이 늦어지고 있습니다.',
+    subTittle: '조금 뒤 다시 시도해 주세요.',
+    resetErrorBoundary: () => {},
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    title: '에러가 발생 했습니다.',
+    subTittle: '관리자에게 문의해 주세요.',
+  },
+};

--- a/src/components/errors/error-section/index.ts
+++ b/src/components/errors/error-section/index.ts
@@ -1,0 +1,3 @@
+import ErrorSection from './error-section';
+
+export default ErrorSection;

--- a/src/components/errors/local-api-error-boundary/index.ts
+++ b/src/components/errors/local-api-error-boundary/index.ts
@@ -1,0 +1,3 @@
+import LocalApiErrorBoundary from './local-api-error-boundary';
+
+export default LocalApiErrorBoundary;

--- a/src/components/errors/local-api-error-boundary/local-api-error-boundary.tsx
+++ b/src/components/errors/local-api-error-boundary/local-api-error-boundary.tsx
@@ -1,0 +1,70 @@
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { useLocation } from 'react-router-dom';
+
+import { HttpStatusCode, isAxiosError } from 'axios';
+import tw from 'twin.macro';
+import { generateServerErrorMessage } from '../../../utils/error';
+import ErrorSection from '../error-section';
+
+interface LocalApiErrorBoundaryProps {
+  children: ReactNode;
+  height?: string | number;
+}
+
+interface FallbackComponentProps extends FallbackProps {
+  className?: string;
+}
+
+function FallbackComponent({
+  error,
+  resetErrorBoundary,
+  className,
+}: FallbackComponentProps) {
+  if (!isAxiosError(error)) {
+    throw error;
+  }
+
+  if (error.response?.status === HttpStatusCode.Unauthorized) {
+    window.location.href = '/login';
+    return null;
+  }
+
+  return (
+    <ErrorSection
+      title={generateServerErrorMessage(error)}
+      subTittle="조금 뒤 다시 시도해 주세요."
+      resetErrorBoundary={resetErrorBoundary}
+      css={[tw`bg-gray-50`]}
+      className={className}
+    />
+  );
+}
+
+function LocalApiErrorBoundary({
+  children,
+  height,
+}: LocalApiErrorBoundaryProps) {
+  const { reset } = useQueryErrorResetBoundary();
+  const { key } = useLocation();
+
+  return (
+    <ErrorBoundary
+      /**
+       * 리렌더링 될 때마다 Fallback의 함수 정의가 재생성 되는건
+       * ErrorBoundary에선 큰 의미가 없다고 생각해 eslint 규칙을 disabled 했습니다.
+       */
+      // eslint-disable-next-line
+      fallbackRender={(props) => (
+        <FallbackComponent {...props} css={{ height }} />
+      )}
+      onReset={reset}
+      resetKeys={[key]}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export default LocalApiErrorBoundary;

--- a/src/components/errors/root-error-boundary/index.ts
+++ b/src/components/errors/root-error-boundary/index.ts
@@ -1,0 +1,3 @@
+import RootErrorBoundary from './root-error-boundary';
+
+export default RootErrorBoundary;

--- a/src/components/errors/root-error-boundary/root-error-boundary.tsx
+++ b/src/components/errors/root-error-boundary/root-error-boundary.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { useLocation } from 'react-router-dom';
+import tw from 'twin.macro';
+import Layout from '../../common/layout';
+import LogoAppBar from '../../common/layout/logo-app-bar';
+import ErrorSection from '../error-section';
+
+interface RootErrorBoundaryProps {
+  children: ReactNode;
+}
+
+function FallbackComponent() {
+  return (
+    <Layout>
+      <LogoAppBar />
+      <ErrorSection
+        title="에러가 발생 했습니다."
+        subTittle="관리자에게 문의해 주세요."
+        css={[tw`flex-1`]}
+      />
+    </Layout>
+  );
+}
+
+function RootErrorBoundary({ children }: RootErrorBoundaryProps) {
+  const { key } = useLocation();
+
+  return (
+    <ErrorBoundary FallbackComponent={FallbackComponent} resetKeys={[key]}>
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export default RootErrorBoundary;

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -4,5 +4,5 @@ const isDevMode = import.meta.env.DEV;
 
 export const axiosInstance = axios.create({
   baseURL: isDevMode ? '/api/' : 'https://celebpick.site/api/',
-  timeout: 10000,
+  timeout: 5000,
 });

--- a/src/config/tanstack-query.ts
+++ b/src/config/tanstack-query.ts
@@ -1,3 +1,13 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      throwOnError: true,
+      retry: false,
+    },
+    mutations: {
+      throwOnError: true,
+    },
+  },
+});

--- a/src/hooks/mutations/useLogin.ts
+++ b/src/hooks/mutations/useLogin.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { HttpStatusCode } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { login } from '../../api/auth';
 import { LoginRequest } from '../../types/auth';
+import { getServerErrorResponse } from '../../utils/error';
 
 const useLogin = () => {
   const queryClient = useQueryClient();
@@ -9,6 +11,12 @@ const useLogin = () => {
 
   return useMutation({
     mutationFn: (req: LoginRequest) => login(req),
+    throwOnError: (error) => {
+      if (getServerErrorResponse(error)?.status === HttpStatusCode.BadRequest) {
+        return false;
+      }
+      return true;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchAuthStatus'] });
       // TODO: 내 프로필 페이지로 이동하게 변경

--- a/src/hooks/mutations/useSignup.ts
+++ b/src/hooks/mutations/useSignup.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { HttpStatusCode } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { signup } from '../../api/auth';
 import { SignupRequest } from '../../types/auth';
+import { getServerErrorResponse } from '../../utils/error';
 
 const useSignup = () => {
   const queryClient = useQueryClient();
@@ -9,6 +11,12 @@ const useSignup = () => {
 
   return useMutation({
     mutationFn: (req: SignupRequest) => signup(req),
+    throwOnError: (error) => {
+      if (getServerErrorResponse(error)?.status === HttpStatusCode.BadRequest) {
+        return false;
+      }
+      return true;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchAuthStatus'] });
       // TODO 내 프로필 페이지로 이동하게 변경

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,11 @@
-import { QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
-import { queryClient } from './config/tanstack-query';
+
 import './index.css';
-import router from './router';
+import App from './app';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <App />
   </React.StrictMode>
 );

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import Layout from '../../components/common/layout';
+import LocalApiErrorBoundary from '../../components/errors/local-api-error-boundary';
 import OutfitFeedSkeleton from '../../features/outfits/outfit-feed/outfit-feed-skeleton';
 import OutfitFilter from '../../features/outfits/outfit-filter';
 import HomeOutfitFeed from './home-outfit-feed';
@@ -9,9 +10,11 @@ function HomePage() {
     <Layout>
       <Layout.LogoAppBar />
       <OutfitFilter />
-      <Suspense fallback={<OutfitFeedSkeleton />}>
-        <HomeOutfitFeed />
-      </Suspense>
+      <LocalApiErrorBoundary>
+        <Suspense fallback={<OutfitFeedSkeleton />}>
+          <HomeOutfitFeed />
+        </Suspense>
+      </LocalApiErrorBoundary>
       <Layout.BottomTabBar />
     </Layout>
   );

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -4,14 +4,14 @@ import Button from '../../components/atoms/button';
 import TextField from '../../components/atoms/text-field';
 import Layout from '../../components/common/layout';
 import useLogin from '../../hooks/mutations/useLogin';
-import useServerErrorResponse from '../../hooks/useServerErrorResponse';
 import { LoginErrorResponse } from '../../types/auth';
 import useLoginForm from './useLoginForm';
+import { getServerErrorResponse } from '../../utils/error';
 
 function LoginPage() {
   const loginForm = useLoginForm();
   const { mutate, error, isPending } = useLogin();
-  const serverError = useServerErrorResponse<LoginErrorResponse>(error);
+  const serverError = getServerErrorResponse<LoginErrorResponse>(error);
 
   return (
     <Layout css={[tw`flex-center`]}>

--- a/src/pages/signup/signup-form.tsx
+++ b/src/pages/signup/signup-form.tsx
@@ -3,15 +3,15 @@ import tw from 'twin.macro';
 import Button from '../../components/atoms/button';
 import TextField from '../../components/atoms/text-field';
 import useSignup from '../../hooks/mutations/useSignup';
-import useServerErrorResponse from '../../hooks/useServerErrorResponse';
 import { SignupErrorResponse } from '../../types/auth';
+import { getServerErrorResponse } from '../../utils/error';
 import UserGenderRadioGroup from './user-gender-radio-group';
 import useSignupForm from './useSignupForm';
 
 function SignupForm() {
   const signupForm = useSignupForm();
   const { mutate, error, isPending } = useSignup();
-  const serverError = useServerErrorResponse<SignupErrorResponse>(error);
+  const serverError = getServerErrorResponse<SignupErrorResponse>(error);
 
   return (
     <form

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -15,15 +15,15 @@ const router: RouterType = createBrowserRouter([
         path: '/',
         element: <HomePage />,
       },
+      {
+        path: '/login',
+        element: <LoginPage />,
+      },
+      {
+        path: '/signup',
+        element: <SignupPage />,
+      },
     ],
-  },
-  {
-    path: '/login',
-    element: <LoginPage />,
-  },
-  {
-    path: '/signup',
-    element: <SignupPage />,
   },
 ]);
 

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,20 +1,15 @@
-import { createBrowserRouter, Outlet } from 'react-router-dom';
-import { QueryParamProvider } from 'use-query-params';
-import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import HomePage from '../pages/home';
 import LoginPage from '../pages/login';
 import SignupPage from '../pages/signup';
+import RouteWrapper from './route-wrapper';
 
-type Router = ReturnType<typeof createBrowserRouter>;
+type RouterType = ReturnType<typeof createBrowserRouter>;
 
-const router: Router = createBrowserRouter([
+const router: RouterType = createBrowserRouter([
   {
     path: '/',
-    element: (
-      <QueryParamProvider adapter={ReactRouter6Adapter}>
-        <Outlet />
-      </QueryParamProvider>
-    ),
+    element: <RouteWrapper />,
     children: [
       {
         path: '/',
@@ -32,4 +27,8 @@ const router: Router = createBrowserRouter([
   },
 ]);
 
-export default router;
+function Router() {
+  return <RouterProvider router={router} />;
+}
+
+export default Router;

--- a/src/router/route-wrapper.tsx
+++ b/src/router/route-wrapper.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+
+function RouteWrapper() {
+  return (
+    <QueryParamProvider adapter={ReactRouter6Adapter}>
+      <Outlet />
+    </QueryParamProvider>
+  );
+}
+
+export default RouteWrapper;

--- a/src/router/route-wrapper.tsx
+++ b/src/router/route-wrapper.tsx
@@ -1,11 +1,17 @@
 import { Outlet } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+import ApiErrorBoundary from '../components/errors/api-error-boundary';
+import RootErrorBoundary from '../components/errors/root-error-boundary';
 
 function RouteWrapper() {
   return (
     <QueryParamProvider adapter={ReactRouter6Adapter}>
-      <Outlet />
+      <RootErrorBoundary>
+        <ApiErrorBoundary>
+          <Outlet />
+        </ApiErrorBoundary>
+      </RootErrorBoundary>
     </QueryParamProvider>
   );
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,11 +1,11 @@
 import { isAxiosError } from 'axios';
 
-const useServerErrorResponse = <ErrorResponseType>(error: Error | null) => {
+export const getServerErrorResponse = <ErrorResponseType>(
+  error: Error | null
+) => {
   if (!isAxiosError<ErrorResponseType>(error) || !error.response) {
     return undefined;
   }
 
   return error.response;
 };
-
-export default useServerErrorResponse;

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,4 +1,4 @@
-import { isAxiosError } from 'axios';
+import { AxiosError, HttpStatusCode, isAxiosError } from 'axios';
 
 export const getServerErrorResponse = <ErrorResponseType>(
   error: Error | null
@@ -8,4 +8,27 @@ export const getServerErrorResponse = <ErrorResponseType>(
   }
 
   return error.response;
+};
+
+export const generateServerErrorMessage = (error: AxiosError) => {
+  // Axios 측에서 서버 요청 타임아웃 제한에 걸린 경우
+  if (error.code === 'ECONNABORTED') {
+    return '연결에 잠시 문제가 발생 했습니다.';
+  }
+
+  const { status } = error.response!;
+  switch (status) {
+    case HttpStatusCode.InternalServerError:
+    case HttpStatusCode.BadGateway:
+    case HttpStatusCode.GatewayTimeout:
+      return '서버 내부에 문제가 발생 했습니다.';
+    case HttpStatusCode.RequestTimeout:
+      return '연결에 잠시 문제가 발생 했습니다.';
+    case HttpStatusCode.NotFound:
+      return '데이터를 찾을 수 없습니다.';
+    case HttpStatusCode.TooManyRequests:
+      return '서버에 너무 많은 요청을 보낼 수 없습니다.';
+    default:
+      return '잠시 연결이 늦어지고 있습니다.';
+  }
 };


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 처리되지 않는 에러를 다루는 `RootErrorBoundary`, API 에러를 전역적으로 처리하는 `ApiErrorBoundary`, 각각의 컴포넌트의 API 에러를 컴포넌트별로 처리하는 `LocalApiErrorBoundary` 컴포넌트를 구현하고, 내부의 fallback에 사용되는 `ErrorSection` 컴포넌트를 구현 했습니다.

### PR Point
- react-router-dom의 `createBrowserRouter`가 구현에 사용된 `RouterProvider`를 ErrorBoundary가 래핑할 수 없어 각각의 Route를 ErrorBoundary로 감싸는 식으로 구현 했습니다. 
- react-router-dom의 `errorElement`는 React Query의 에러를 잡아내기 번거로운것으로 파악되어 `errorElement` 대신 ErrorBoundary로 통일 했습니다.

### 📸 스크린샷
- `ApiErrorBoundary`에서 예외처리를 한 경우

![image](https://github.com/user-attachments/assets/60abd3ef-5717-4595-9f3c-cb4ceeb044d9)

- `LocalApiErrorBoundary`에서 예외처리를 한 경우

![image](https://github.com/user-attachments/assets/110f4e12-db71-497f-8303-dc5fbfc1c718)


- `RootErrorBoundary`에서 예외처리를 한 경우

![image](https://github.com/user-attachments/assets/8d12313a-590a-404d-96fd-c6d3bbe39b70)


closed #39
