### PR TITLE
feat: 스크랩한 코디 그리드와 리스트 페이지 구현

### DIFF
--- a/src/api/scrap.ts
+++ b/src/api/scrap.ts
@@ -1,4 +1,25 @@
 import { axiosInstance } from '../config/axios';
+import {
+  MyScrapOutfitPostListRequest,
+  MyScrapOutfitPostListResponse,
+} from '../types/scrap';
+
+export const fetchMyScrapOutfitPosts = async (
+  req?: MyScrapOutfitPostListRequest,
+  page?: number
+) => {
+  return (
+    await axiosInstance.get<MyScrapOutfitPostListResponse>(
+      '/users/me/outfit-posts/scraps',
+      {
+        params: {
+          ...req?.queryParams,
+          page,
+        },
+      }
+    )
+  ).data;
+};
 
 export const scrapOutfitPost = async (outfitPostId: number) => {
   await axiosInstance.post(`/outfit-posts/${outfitPostId}/scraps/`);

--- a/src/components/common/infinite-scroll-fetch-trigger/index.ts
+++ b/src/components/common/infinite-scroll-fetch-trigger/index.ts
@@ -1,0 +1,3 @@
+import InfiniteScrollFetchTrigger from './infinite-scroll-fetch-trigger';
+
+export default InfiniteScrollFetchTrigger;

--- a/src/components/common/infinite-scroll-fetch-trigger/infinite-scroll-fetch-trigger.tsx
+++ b/src/components/common/infinite-scroll-fetch-trigger/infinite-scroll-fetch-trigger.tsx
@@ -1,15 +1,19 @@
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
-interface OutfitFeedFetchTriggerProps {
+interface InfiniteScrollFetchTriggerProps {
   hasNextPage: boolean;
   fetchNextPage: () => void;
 }
 
-function OutfitFeedFetchTrigger({
+/**
+ * 해당 컴포넌트가 화면상에 보였을 때 `hasNextPage`일 경우
+ * `fetchNextPage` 함수를 호출하는 트리거 컴포넌트 입니다.
+ */
+function InfiniteScrollFetchTrigger({
   hasNextPage,
   fetchNextPage,
-}: OutfitFeedFetchTriggerProps) {
+}: InfiniteScrollFetchTriggerProps) {
   const { ref, inView } = useInView();
 
   useEffect(() => {
@@ -21,4 +25,4 @@ function OutfitFeedFetchTrigger({
   return <div ref={ref} className="h-1" />;
 }
 
-export default OutfitFeedFetchTrigger;
+export default InfiniteScrollFetchTrigger;

--- a/src/components/common/layout/bottom-tab-bar.tsx
+++ b/src/components/common/layout/bottom-tab-bar.tsx
@@ -51,7 +51,7 @@ function BottomTabBar() {
         <TabNavigator
           icon={<BookmarkBorderOutlinedIcon />}
           label="스크랩"
-          to=""
+          to="/users/me/scraps"
         />
         <TabNavigator
           icon={<PersonOutlineOutlinedIcon />}

--- a/src/components/common/layout/title-with-back-app-bar.tsx
+++ b/src/components/common/layout/title-with-back-app-bar.tsx
@@ -13,7 +13,7 @@ function TitleWithBackAppBar({ title, navigateTo }: TitleWithBackAppBarProps) {
   const navigate = useNavigate();
 
   return (
-    <div className="custom-app-bar-container">
+    <div className="custom-app-bar-container" css={[tw`sticky top-0`]}>
       <IconButton
         icon={<ArrowBackIosNewRoundedIcon />}
         onClick={() => navigate(navigateTo)}

--- a/src/components/templates/grid/grid.tsx
+++ b/src/components/templates/grid/grid.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+import tw from 'twin.macro';
+
+interface GridProps {
+  /**
+   * Grid의 열의 갯수 입니다.
+   */
+  col?: number;
+
+  /**
+   * Grid Cell에 해당 됩니다.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Grid Cell이 정사각형으로 나타나는 그리드 컨테이너 컴포넌트 입니다.
+ *
+ * @example
+ *
+ * ```tsx
+ * // 결과
+ * // ■ ■ ■
+ * // ■ □ □
+ *
+ * <Grid>
+ *   <div>■</div>
+ *   <div>■</div>
+ *   <div>■</div>
+ *   <div>■</div>
+ * </Grid>
+ * ```
+ */
+function Grid({ col = 3, children }: GridProps) {
+  return (
+    <div
+      css={[
+        tw`grid gap-1 p-1 [>*]:aspect-square`,
+        { gridTemplateColumns: `repeat(${col}, minmax(0, 1fr))` },
+      ]}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default Grid;

--- a/src/components/templates/grid/index.stories.tsx
+++ b/src/components/templates/grid/index.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Skeleton from '../../atoms/skeleton';
+import Grid from './index';
+
+const meta: Meta<typeof Grid> = {
+  component: Grid,
+  decorators: [
+    (Story) => (
+      <div className="w-60 border border-solid border-black">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: Array.from({ length: 10 }).map((_, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <Skeleton key={i} height="100%" />
+    )),
+  },
+};
+
+export const FourColumn: Story = {
+  args: {
+    ...Default.args,
+    col: 4,
+  },
+};

--- a/src/components/templates/grid/index.ts
+++ b/src/components/templates/grid/index.ts
@@ -1,0 +1,3 @@
+import Grid from './grid';
+
+export default Grid;

--- a/src/features/outfits/outfit-feed/outfit-feed.tsx
+++ b/src/features/outfits/outfit-feed/outfit-feed.tsx
@@ -4,8 +4,8 @@ import type {
 } from '@tanstack/react-query';
 import type { ComponentPropsWithoutRef } from 'react';
 import tw from 'twin.macro';
+import InfiniteScrollFetchTrigger from '../../../components/common/infinite-scroll-fetch-trigger';
 import type { OutfitPostListResponse } from '../../../types/outfit';
-import OutfitFeedFetchTrigger from './outfit-feed-fetch-trigger';
 import OutfitFeedPostLoader from './outfit-feed-post-loader';
 import OutfitPostList from './outfit-post-list';
 
@@ -34,7 +34,7 @@ function OutfitFeed({
     <div css={[tw`w-full h-full`]} {...props}>
       <OutfitPostList pagesData={data.pages} />
       <OutfitFeedPostLoader isFetching={isFetchingNextPage} />
-      <OutfitFeedFetchTrigger
+      <InfiniteScrollFetchTrigger
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}
       />

--- a/src/features/outfits/outfit-feed/outfit-post/outfit-post.tsx
+++ b/src/features/outfits/outfit-feed/outfit-post/outfit-post.tsx
@@ -1,4 +1,5 @@
-import { ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef, useEffect, useRef } from 'react';
+import { useParams } from 'react-router-dom';
 import tw from 'twin.macro';
 import { OutfitPostListResponse } from '../../../../types/outfit';
 import OutfitPostHeader from './outfit-post-header';
@@ -9,8 +10,20 @@ interface OutfitPostProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 function OutfitPost({ outfitPost, ...props }: OutfitPostProps) {
+  const outfitPostRef = useRef<HTMLDivElement>(null);
+  const { outfitPostId: outfitPostIdParam } = useParams();
+
+  useEffect(() => {
+    if (!outfitPostIdParam || !outfitPostRef.current) {
+      return;
+    }
+    if (Number(outfitPostIdParam) === outfitPost.id) {
+      outfitPostRef.current.scrollIntoView();
+    }
+  }, [outfitPostIdParam, outfitPostRef, outfitPost]);
+
   return (
-    <div css={[tw`flex flex-col`]} {...props}>
+    <div ref={outfitPostRef} css={[tw`flex flex-col`]} {...props}>
       <OutfitPostHeader creator={outfitPost.creator} />
       <OutfitPostSlider outfitPost={outfitPost} />
     </div>

--- a/src/features/outfits/outfit-scrap-button/base-outfit-scrap-button.tsx
+++ b/src/features/outfits/outfit-scrap-button/base-outfit-scrap-button.tsx
@@ -31,6 +31,7 @@ function BaseOutfitScrapButton({
     typeof updatedScrapCount === 'undefined'
       ? context.scrapCount
       : updatedScrapCount;
+  const showScrapCount = typeof scrapCount !== 'undefined';
 
   const ScrapIcon = isScrapped
     ? BookmarkRoundedIcon
@@ -43,9 +44,10 @@ function BaseOutfitScrapButton({
       icon={
         <>
           <ScrapIcon css={[tw`mr-0.5`, isScrapped && tw`fill-yellow-300`]} />
-          <span css={[tw`font-medium`]}>{scrapCount}</span>
+          {showScrapCount && <span css={[tw`font-medium`]}>{scrapCount}</span>}
         </>
       }
+      className={context.className}
     />
   );
 }

--- a/src/features/outfits/outfit-scrap-button/context.tsx
+++ b/src/features/outfits/outfit-scrap-button/context.tsx
@@ -4,7 +4,8 @@ export interface OutfitScrapButtonContextType {
   outfitPostId?: number;
   outfitItemId?: number;
   isScrapped: boolean | null;
-  scrapCount: number;
+  scrapCount?: number;
+  className?: string;
 }
 
 export const OutfitScrapButtonContext =

--- a/src/features/outfits/outfit-scrap-button/outfit-item-scrap-button.tsx
+++ b/src/features/outfits/outfit-scrap-button/outfit-item-scrap-button.tsx
@@ -17,18 +17,28 @@ function OutfitItemScrapButton() {
   const scrapOutfitItem = useCallback(() => {
     mutateScrap(outfitItemId!);
     setUpdatedIsScrapped(true);
-    setUpdatedScrapCount(scrapCount + 1);
+    if (typeof scrapCount === 'number') {
+      setUpdatedScrapCount(scrapCount + 1);
+    }
   }, [mutateScrap, scrapCount, outfitItemId]);
 
   const unscrapOutfitItem = useCallback(() => {
     mutateUnscrap(outfitItemId!);
     setUpdatedIsScrapped(false);
-    setUpdatedScrapCount(scrapCount - 1);
+    if (typeof scrapCount === 'number') {
+      setUpdatedScrapCount(scrapCount - 1);
+    }
   }, [mutateUnscrap, scrapCount, outfitItemId]);
 
+  const handleClickButton = isScrapped ? unscrapOutfitItem : scrapOutfitItem;
+
   return (
+    // propagation 되는지 테스트해보기
     <BaseOutfitScrapButton
-      onClick={isScrapped ? unscrapOutfitItem : scrapOutfitItem}
+      onClick={(event) => {
+        event.stopPropagation();
+        handleClickButton();
+      }}
       updatedIsScrapped={updatedIsScrapped}
       updatedScrapCount={updatedScrapCount}
       disabled={isPendingScrap || isPendingUnscrap}

--- a/src/features/outfits/outfit-scrap-button/outfit-post-scrap-button.tsx
+++ b/src/features/outfits/outfit-scrap-button/outfit-post-scrap-button.tsx
@@ -17,18 +17,27 @@ function OutfitPostScrapButton() {
   const scrapOutfitPost = useCallback(() => {
     mutateScrap(outfitPostId!);
     setUpdatedIsScrapped(true);
-    setUpdatedScrapCount(scrapCount + 1);
+    if (typeof scrapCount === 'number') {
+      setUpdatedScrapCount(scrapCount + 1);
+    }
   }, [mutateScrap, scrapCount, outfitPostId]);
 
   const unscrapOutfitPost = useCallback(() => {
     mutateUnscrap(outfitPostId!);
     setUpdatedIsScrapped(false);
-    setUpdatedScrapCount(scrapCount - 1);
+    if (typeof scrapCount === 'number') {
+      setUpdatedScrapCount(scrapCount - 1);
+    }
   }, [mutateUnscrap, scrapCount, outfitPostId]);
+
+  const handleClickButton = isScrapped ? unscrapOutfitPost : scrapOutfitPost;
 
   return (
     <BaseOutfitScrapButton
-      onClick={isScrapped ? unscrapOutfitPost : scrapOutfitPost}
+      onClick={(event) => {
+        event.stopPropagation();
+        handleClickButton();
+      }}
       updatedIsScrapped={updatedIsScrapped}
       updatedScrapCount={updatedScrapCount}
       disabled={isPendingScrap || isPendingUnscrap}

--- a/src/features/outfits/outfit-scrap-button/outfit-scrap-button.tsx
+++ b/src/features/outfits/outfit-scrap-button/outfit-scrap-button.tsx
@@ -6,7 +6,8 @@ export interface OutfitScrapButtonProps {
   outfitPostId?: number;
   outfitItemId?: number;
   isScrapped: boolean | null;
-  scrapCount: number;
+  scrapCount?: number;
+  className?: string;
 }
 
 function OutfitScrapButton(props: OutfitScrapButtonProps) {

--- a/src/hooks/mutations/useScrapOutfitItem.ts
+++ b/src/hooks/mutations/useScrapOutfitItem.ts
@@ -1,13 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { HttpStatusCode } from 'axios';
 import { scrapOutfitItem } from '../../api/scrap';
+import { getServerErrorResponse } from '../../utils/error';
 
 const useScrapOutfitItem = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (outfitItemId: number) => scrapOutfitItem(outfitItemId),
+    throwOnError: (error) => {
+      if (getServerErrorResponse(error)?.status === HttpStatusCode.Conflict) {
+        return false;
+      }
+      return true;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
+      queryClient.invalidateQueries({
+        queryKey: ['fetchMyScrapOutfitPostList'],
+      });
     },
   });
 };

--- a/src/hooks/mutations/useScrapOutfitPost.ts
+++ b/src/hooks/mutations/useScrapOutfitPost.ts
@@ -1,13 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { HttpStatusCode } from 'axios';
 import { scrapOutfitPost } from '../../api/scrap';
+import { getServerErrorResponse } from '../../utils/error';
 
 const useScrapOutfitPost = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (outfitPostId: number) => scrapOutfitPost(outfitPostId),
+    throwOnError: (error) => {
+      if (getServerErrorResponse(error)?.status === HttpStatusCode.Conflict) {
+        return false;
+      }
+      return true;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
+      queryClient.invalidateQueries({
+        queryKey: ['fetchMyScrapOutfitPostList'],
+      });
     },
   });
 };

--- a/src/hooks/mutations/useUnscrapOutfitItem.ts
+++ b/src/hooks/mutations/useUnscrapOutfitItem.ts
@@ -1,13 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { HttpStatusCode } from 'axios';
 import { unscrapOutfitItem } from '../../api/scrap';
+import { getServerErrorResponse } from '../../utils/error';
 
 const useUnscrapOutfitItem = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (outfitItemId: number) => unscrapOutfitItem(outfitItemId),
+    throwOnError: (error) => {
+      if (getServerErrorResponse(error)?.status === HttpStatusCode.BadRequest) {
+        return false;
+      }
+      return true;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
+      queryClient.invalidateQueries({
+        queryKey: ['fetchMyScrapOutfitPostList'],
+      });
     },
   });
 };

--- a/src/hooks/mutations/useUnscrapOutfitPost.ts
+++ b/src/hooks/mutations/useUnscrapOutfitPost.ts
@@ -1,13 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { HttpStatusCode } from 'axios';
 import { unscrapOutfitPost } from '../../api/scrap';
+import { getServerErrorResponse } from '../../utils/error';
 
 const useUnscrapOutfitPost = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (outfitPostId: number) => unscrapOutfitPost(outfitPostId),
+    throwOnError: (error) => {
+      if (getServerErrorResponse(error)?.status === HttpStatusCode.BadRequest) {
+        return false;
+      }
+      return true;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
+      queryClient.invalidateQueries({
+        queryKey: ['fetchMyScrapOutfitPostList'],
+      });
     },
   });
 };

--- a/src/hooks/queries/useFetchMyScrapOutfitPostList.ts
+++ b/src/hooks/queries/useFetchMyScrapOutfitPostList.ts
@@ -1,0 +1,14 @@
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { fetchMyScrapOutfitPosts } from '../../api/scrap';
+import { MyScrapOutfitPostListRequest } from '../../types/scrap';
+
+const useFetchMyScrapOutfitPostList = (req?: MyScrapOutfitPostListRequest) => {
+  return useSuspenseInfiniteQuery({
+    queryKey: ['fetchMyScrapOutfitPostList', req],
+    queryFn: ({ pageParam }) => fetchMyScrapOutfitPosts(req, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: ({ next }) => next,
+  });
+};
+
+export default useFetchMyScrapOutfitPostList;

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,6 @@
 
 @layer components {
   .custom-app-bar-container {
-    @apply h-16 border-b border-solid border-gray-100 bg-white px-4 flex-y-center;
+    @apply z-20 h-16 w-full border-b border-solid border-gray-100 bg-white px-4 flex-y-center;
   }
 }

--- a/src/pages/my-scrap-outfit-post/index.ts
+++ b/src/pages/my-scrap-outfit-post/index.ts
@@ -1,0 +1,3 @@
+import MyScrapOutfitPostPage from './my-scrap-outfit-post';
+
+export default MyScrapOutfitPostPage;

--- a/src/pages/my-scrap-outfit-post/my-scrap-outfit-post.tsx
+++ b/src/pages/my-scrap-outfit-post/my-scrap-outfit-post.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react';
+import Layout from '../../components/common/layout';
+import LocalApiErrorBoundary from '../../components/errors/local-api-error-boundary';
+import OutfitFeed from '../../features/outfits/outfit-feed';
+import OutfitFeedSkeleton from '../../features/outfits/outfit-feed/outfit-feed-skeleton';
+import useFetchMyScrapOutfitPostList from '../../hooks/queries/useFetchMyScrapOutfitPostList';
+
+function MyScrapOutfitPostPage() {
+  return (
+    <Layout>
+      <Layout.TitleWithBackAppBar
+        title="스크랩한 코디"
+        navigateTo="/users/me/scraps"
+      />
+      <LocalApiErrorBoundary>
+        <Suspense fallback={<OutfitFeedSkeleton />}>
+          <OutfitFeed
+            // FIXME URL로 접근했을 시 데이터가 불러와지지않아 해당 포스트로 스크롤되지 않는 버그 존재
+            // TODO 커서 방식으로 변경하면 req cursor에 outfitPostId값 추가
+            suspenseInfiniteQueryResult={useFetchMyScrapOutfitPostList()}
+          />
+        </Suspense>
+      </LocalApiErrorBoundary>
+    </Layout>
+  );
+}
+
+export default MyScrapOutfitPostPage;

--- a/src/pages/my-scrap/index.ts
+++ b/src/pages/my-scrap/index.ts
@@ -1,0 +1,3 @@
+import MyScrapPage from './my-scrap';
+
+export default MyScrapPage;

--- a/src/pages/my-scrap/my-scrap-grid-skeleton.tsx
+++ b/src/pages/my-scrap/my-scrap-grid-skeleton.tsx
@@ -1,0 +1,19 @@
+import Skeleton from '../../components/atoms/skeleton';
+import Grid from '../../components/templates/grid';
+
+function MyScrapGridSkeleton() {
+  return (
+    <Grid>
+      {Array.from({ length: 15 }).map((_, i) => (
+        /**
+         * Skeleton UI는 index를 key로 사용해도 렌더링 상 문제가 없을 것이라 판단해
+         * eslint 에러를 disabled 했습니다.
+         */
+        // eslint-disable-next-line react/no-array-index-key
+        <Skeleton key={i} height="100%" />
+      ))}
+    </Grid>
+  );
+}
+
+export default MyScrapGridSkeleton;

--- a/src/pages/my-scrap/my-scrap-outfit-item-grid.tsx
+++ b/src/pages/my-scrap/my-scrap-outfit-item-grid.tsx
@@ -1,0 +1,5 @@
+function MyScrapOutfitItemGrid() {
+  return <div> </div>;
+}
+
+export default MyScrapOutfitItemGrid;

--- a/src/pages/my-scrap/my-scrap-outfit-post-grid.tsx
+++ b/src/pages/my-scrap/my-scrap-outfit-post-grid.tsx
@@ -1,0 +1,66 @@
+import { useNavigate } from 'react-router-dom';
+import tw from 'twin.macro';
+import Spinner from '../../components/atoms/spinner';
+import InfiniteScrollFetchTrigger from '../../components/common/infinite-scroll-fetch-trigger';
+import Grid from '../../components/templates/grid';
+import OutfitScrapButton from '../../features/outfits/outfit-scrap-button';
+import useFetchMyScrapOutfitPostList from '../../hooks/queries/useFetchMyScrapOutfitPostList';
+import { MyScrapOutfitPostListResponse } from '../../types/scrap';
+
+interface GridContentProps {
+  pagesData: Array<MyScrapOutfitPostListResponse>;
+}
+
+function GridContent({ pagesData }: GridContentProps) {
+  const navigate = useNavigate();
+
+  const handleClickGridItem = (outfitPostId: number) => {
+    navigate(`/users/me/scraps/outfit-posts/${outfitPostId}`);
+  };
+
+  return (
+    <Grid>
+      {pagesData.map(({ results: outfitPostList }) =>
+        outfitPostList.map((outfitPost) => (
+          <div
+            key={outfitPost.id}
+            role="gridcell"
+            onClick={() => handleClickGridItem(outfitPost.id)}
+            onKeyDown={() => handleClickGridItem(outfitPost.id)}
+            tabIndex={0}
+            css={[tw`relative cursor-pointer`]}
+          >
+            <img
+              src={outfitPost.imageUrl}
+              alt={outfitPost.title}
+              css={[tw`w-full h-full`]}
+            />
+            <OutfitScrapButton
+              outfitPostId={outfitPost.id}
+              isScrapped={outfitPost.isScrapped}
+              css={[tw`absolute top-0 right-0`]}
+            />
+          </div>
+        ))
+      )}
+    </Grid>
+  );
+}
+
+function MyScrapOutfitPostGrid() {
+  const { data, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useFetchMyScrapOutfitPostList();
+
+  return (
+    <div>
+      <GridContent pagesData={data.pages} />
+      {isFetchingNextPage && <Spinner size={30} css={tw`py-4`} />}
+      <InfiniteScrollFetchTrigger
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+      />
+    </div>
+  );
+}
+
+export default MyScrapOutfitPostGrid;

--- a/src/pages/my-scrap/my-scrap-tab-bar.tsx
+++ b/src/pages/my-scrap/my-scrap-tab-bar.tsx
@@ -1,0 +1,40 @@
+import tw from 'twin.macro';
+import { MyScrapTabType } from './types';
+import useTabQueryParam from './useTabQueryParam';
+
+interface MyScrapTabProps {
+  value: MyScrapTabType;
+  label: string;
+}
+
+function MyScrapTab({ value, label }: MyScrapTabProps) {
+  const [query, setQuery] = useTabQueryParam();
+
+  const isActive = query === value;
+
+  return (
+    <button
+      type="button"
+      onClick={() => setQuery(value)}
+      css={[
+        tw`h-16 border-solid border-b-2 border-gray-300`,
+        isActive && tw`border-black`,
+      ]}
+    >
+      <span css={[tw`font-medium text-gray-300`, isActive && tw`text-black`]}>
+        {label}
+      </span>
+    </button>
+  );
+}
+
+function MyScrapTabBar() {
+  return (
+    <div css={[tw`grid grid-cols-2`]}>
+      <MyScrapTab value="outfitPost" label="스크랩한 코디" />
+      <MyScrapTab value="outfitItem" label="스크랩한 아이템" />
+    </div>
+  );
+}
+
+export default MyScrapTabBar;

--- a/src/pages/my-scrap/my-scrap.tsx
+++ b/src/pages/my-scrap/my-scrap.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from 'react';
+import Layout from '../../components/common/layout';
+import LocalApiErrorBoundary from '../../components/errors/local-api-error-boundary';
+import MyScrapGridSkeleton from './my-scrap-grid-skeleton';
+import MyScrapOutfitItemGrid from './my-scrap-outfit-item-grid';
+import MyScrapOutfitPostGrid from './my-scrap-outfit-post-grid';
+import MyScrapTabBar from './my-scrap-tab-bar';
+import { MyScrapTabType } from './types';
+import useTabQueryParam from './useTabQueryParam';
+
+function MyScrapPage() {
+  const [tab] = useTabQueryParam();
+
+  const MyScrapGrid =
+    tab === ('outfitPost' satisfies MyScrapTabType)
+      ? MyScrapOutfitPostGrid
+      : MyScrapOutfitItemGrid;
+
+  return (
+    <Layout>
+      <Layout.LogoAppBar />
+      <MyScrapTabBar />
+      <LocalApiErrorBoundary>
+        <Suspense fallback={<MyScrapGridSkeleton />}>
+          <MyScrapGrid />
+        </Suspense>
+      </LocalApiErrorBoundary>
+      <Layout.BottomTabBar />
+    </Layout>
+  );
+}
+
+export default MyScrapPage;

--- a/src/pages/my-scrap/types.ts
+++ b/src/pages/my-scrap/types.ts
@@ -1,0 +1,1 @@
+export type MyScrapTabType = 'outfitPost' | 'outfitItem';

--- a/src/pages/my-scrap/useTabQueryParam.ts
+++ b/src/pages/my-scrap/useTabQueryParam.ts
@@ -1,0 +1,11 @@
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+import { MyScrapTabType } from './types';
+
+const useTabQueryParam = () => {
+  return useQueryParam(
+    'tab',
+    withDefault(StringParam, 'outfitPost' satisfies MyScrapTabType)
+  );
+};
+
+export default useTabQueryParam;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import HomePage from '../pages/home';
 import LoginPage from '../pages/login';
 import MyScrapPage from '../pages/my-scrap';
+import MyScrapOutfitPostPage from '../pages/my-scrap-outfit-post';
 import SignupPage from '../pages/signup';
 import RouteWrapper from './route-wrapper';
 
@@ -27,6 +28,10 @@ const router: RouterType = createBrowserRouter([
       {
         path: '/users/me/scraps',
         element: <MyScrapPage />,
+      },
+      {
+        path: '/users/me/scraps/outfit-posts/:outfitPostId',
+        element: <MyScrapOutfitPostPage />,
       },
     ],
   },

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import HomePage from '../pages/home';
 import LoginPage from '../pages/login';
+import MyScrapPage from '../pages/my-scrap';
 import SignupPage from '../pages/signup';
 import RouteWrapper from './route-wrapper';
 
@@ -22,6 +23,10 @@ const router: RouterType = createBrowserRouter([
       {
         path: '/signup',
         element: <SignupPage />,
+      },
+      {
+        path: '/users/me/scraps',
+        element: <MyScrapPage />,
       },
     ],
   },

--- a/src/types/scrap.ts
+++ b/src/types/scrap.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryParams } from './api';
+import { OutfitPostListResponse } from './outfit';
+
+export interface MyScrapOutfitPostListRequest {
+  queryParams: PaginationQueryParams;
+}
+
+export type MyScrapOutfitPostListResponse = OutfitPostListResponse;


### PR DESCRIPTION
# Pull Request
### 작업한 내용
스크랩 페이지의 스크랩한 코디 탭 내부 코디 그리드와, 그리드 아이템을 눌렀을 경우 나타나는 리스트 페이지를 구현 했습니다.

### 작업 상세 내용
 - 스크랩한 코디 리스트 조회 쿼리 구현
 - Grid 컴포넌트 구현
 - 스크랩한 코디 그리드 마크업
 - 스크랩한 코드 그리드 무한 스크롤 구현
 - 코디 스크랩 API 연동
 - 스크랩한 코디 리스트 페이지 구현

### PR Point
- 스크랩한 코디(outfit-post) 페이지에 URL로 접근했을 시 데이터가 불러와지지않아 해당 포스트로 스크롤되지 않는 버그 존재 합니다. 추후 커서 방식으로 변경하면 req cursor에 outfitPostId값을 추가해서 해결 가능합니다.

### 📸 스크린샷
- 스크랩 페이지

![image](https://github.com/user-attachments/assets/1792ab48-05ae-4309-9fa6-e47893c0028c)

- 스크랩한 코디 페이지

![image](https://github.com/user-attachments/assets/6610873a-69d0-4946-9e0c-edbbef36500d)


closed #62
