### PR TITLE
feat: 스크랩한 코디 아이템 그리드와 리스트 페이지 구현

### DIFF
--- a/src/api/scrap.ts
+++ b/src/api/scrap.ts
@@ -1,5 +1,7 @@
 import { axiosInstance } from '../config/axios';
 import {
+  MyScrapOutfitItemListRequest,
+  MyScrapOutfitItemListResponse,
   MyScrapOutfitPostListRequest,
   MyScrapOutfitPostListResponse,
 } from '../types/scrap';
@@ -11,6 +13,23 @@ export const fetchMyScrapOutfitPosts = async (
   return (
     await axiosInstance.get<MyScrapOutfitPostListResponse>(
       '/users/me/outfit-posts/scraps',
+      {
+        params: {
+          ...req?.queryParams,
+          page,
+        },
+      }
+    )
+  ).data;
+};
+
+export const fetchMyScrapOutfitItems = async (
+  req?: MyScrapOutfitItemListRequest,
+  page?: number
+) => {
+  return (
+    await axiosInstance.get<MyScrapOutfitItemListResponse>(
+      '/users/me/outfit-items/scraps',
       {
         params: {
           ...req?.queryParams,

--- a/src/components/atoms/chip/chip.tsx
+++ b/src/components/atoms/chip/chip.tsx
@@ -25,8 +25,8 @@ const outlineStyle = (color: ChipProps['color']) => {
     return null;
   }
   return css`
-    color: ${tailwindColors[color]['400']};
-    border: solid 1px ${tailwindColors[color]['300']};
+    color: ${tailwindColors[color]['500']};
+    border: solid 1px ${tailwindColors[color]['400']};
   `;
 };
 

--- a/src/hooks/mutations/useScrapOutfitItem.ts
+++ b/src/hooks/mutations/useScrapOutfitItem.ts
@@ -16,9 +16,6 @@ const useScrapOutfitItem = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
-      queryClient.invalidateQueries({
-        queryKey: ['fetchMyScrapOutfitPostList'],
-      });
     },
   });
 };

--- a/src/hooks/mutations/useScrapOutfitItem.ts
+++ b/src/hooks/mutations/useScrapOutfitItem.ts
@@ -16,6 +16,9 @@ const useScrapOutfitItem = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
+      queryClient.invalidateQueries({
+        queryKey: ['fetchMyScrapOutfitItemList'],
+      });
     },
   });
 };

--- a/src/hooks/mutations/useUnscrapOutfitItem.ts
+++ b/src/hooks/mutations/useUnscrapOutfitItem.ts
@@ -16,6 +16,9 @@ const useUnscrapOutfitItem = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
+      queryClient.invalidateQueries({
+        queryKey: ['fetchMyScrapOutfitItemList'],
+      });
     },
   });
 };

--- a/src/hooks/mutations/useUnscrapOutfitItem.ts
+++ b/src/hooks/mutations/useUnscrapOutfitItem.ts
@@ -16,9 +16,6 @@ const useUnscrapOutfitItem = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fetchOutfitPostList'] });
-      queryClient.invalidateQueries({
-        queryKey: ['fetchMyScrapOutfitPostList'],
-      });
     },
   });
 };

--- a/src/hooks/queries/useFetchMyScrapOutfitItemList.ts
+++ b/src/hooks/queries/useFetchMyScrapOutfitItemList.ts
@@ -1,0 +1,14 @@
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { fetchMyScrapOutfitItems } from '../../api/scrap';
+import { MyScrapOutfitItemListRequest } from '../../types/scrap';
+
+const useFetchMyScrapOutfitItemList = (req?: MyScrapOutfitItemListRequest) => {
+  return useSuspenseInfiniteQuery({
+    queryKey: ['fetchMyScrapOutfitItemList', req],
+    queryFn: ({ pageParam }) => fetchMyScrapOutfitItems(req, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: ({ next }) => next,
+  });
+};
+
+export default useFetchMyScrapOutfitItemList;

--- a/src/pages/my-scrap-outfit-item/index.ts
+++ b/src/pages/my-scrap-outfit-item/index.ts
@@ -1,0 +1,3 @@
+import MyScrapOutfitItemPage from './my-scrap-outfit-item';
+
+export default MyScrapOutfitItemPage;

--- a/src/pages/my-scrap-outfit-item/my-scrap-outfit-item.tsx
+++ b/src/pages/my-scrap-outfit-item/my-scrap-outfit-item.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react';
+import Layout from '../../components/common/layout';
+import LocalApiErrorBoundary from '../../components/errors/local-api-error-boundary';
+import OutfitItemList from './outfit-item-list';
+import OutfitItemListSkeleton from './outfit-item-list-skeleton';
+
+function MyScrapOutfitItemPage() {
+  return (
+    <Layout>
+      <Layout.TitleWithBackAppBar
+        title="스크랩한 아이템"
+        navigateTo="/users/me/scraps?tab=outfitItem"
+      />
+      <LocalApiErrorBoundary>
+        <Suspense fallback={<OutfitItemListSkeleton />}>
+          {/* FIXME URL로 접근했을 시 데이터가 불러와지지않아 해당 포스트로 스크롤되지 않는 버그 존재 */}
+          {/* TODO 커서 방식으로 변경하면 req cursor에 outfitItemtId값 추가 */}
+          <OutfitItemList />
+        </Suspense>
+      </LocalApiErrorBoundary>
+    </Layout>
+  );
+}
+
+export default MyScrapOutfitItemPage;

--- a/src/pages/my-scrap-outfit-item/outfit-item-list-content.tsx
+++ b/src/pages/my-scrap-outfit-item/outfit-item-list-content.tsx
@@ -1,0 +1,93 @@
+import ArrowCircleRightOutlinedIcon from '@mui/icons-material/ArrowCircleRightOutlined';
+import { useEffect, useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import tw from 'twin.macro';
+import Chip from '../../components/atoms/chip';
+import OutfitScrapButton from '../../features/outfits/outfit-scrap-button';
+import { MyScrapOutfitItemListResponse } from '../../types/scrap';
+
+interface OutfitItemListContentProps {
+  pagesData: Array<MyScrapOutfitItemListResponse>;
+}
+
+interface OutfitItemListRowProps {
+  outfitItem: MyScrapOutfitItemListResponse['results'][number];
+}
+
+function EmptyView() {
+  return (
+    <div className="h-40 flex-center">아직 스크랩한 코디가 없습니다😶</div>
+  );
+}
+
+function OutfitItemListRow({ outfitItem }: OutfitItemListRowProps) {
+  const outfitItemRef = useRef<HTMLLIElement>(null);
+  const { outfitItemId: outfitItemIdParam } = useParams();
+
+  useEffect(() => {
+    if (!outfitItemIdParam || !outfitItemRef.current) {
+      return;
+    }
+    if (Number(outfitItemIdParam) === outfitItem.id) {
+      outfitItemRef.current.scrollIntoView();
+    }
+  }, [outfitItemIdParam, outfitItemRef, outfitItem]);
+
+  return (
+    <li
+      ref={outfitItemRef}
+      key={outfitItem.id}
+      css={[tw`flex-y-center flex-wrap gap-x-2.5 p-3 border-solid border-b `]}
+    >
+      <div css={[tw`relative`]}>
+        <img
+          src={outfitItem.imageUrl}
+          alt={outfitItem.name}
+          css={[tw`w-28 h-28 rounded`]}
+        />
+        <OutfitScrapButton
+          outfitItemId={outfitItem.id}
+          isScrapped={outfitItem.isScrapped}
+          css={[tw`absolute top-0 right-0 p-1`]}
+        />
+      </div>
+      <Chip label={outfitItem.brand.name} />
+      <p css={[tw`flex-1 line-clamp-3 break-words font-medium`]}>
+        {outfitItem.name}
+      </p>
+      {!!outfitItem.purchaseLink && (
+        <div css={[tw`flex justify-end w-full`]}>
+          <a
+            href={outfitItem.purchaseLink}
+            target="_blank"
+            type="button"
+            css={[tw`flex-y-center gap-1 text-gray-700 p-1`]}
+            rel="noreferrer"
+          >
+            <span css={[tw`font-semibold pt-[1px]`]}>구매하러 가기</span>
+            <ArrowCircleRightOutlinedIcon />
+          </a>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function OutfitItemListContent({ pagesData }: OutfitItemListContentProps) {
+  const isEmpty = pagesData[0].count === 0;
+  if (isEmpty) {
+    return <EmptyView />;
+  }
+
+  return (
+    <ul>
+      {pagesData.map(({ results: outfitItemList }) =>
+        outfitItemList.map((outfitItem) => (
+          <OutfitItemListRow key={outfitItem.id} outfitItem={outfitItem} />
+        ))
+      )}
+    </ul>
+  );
+}
+
+export default OutfitItemListContent;

--- a/src/pages/my-scrap-outfit-item/outfit-item-list-skeleton.tsx
+++ b/src/pages/my-scrap-outfit-item/outfit-item-list-skeleton.tsx
@@ -1,0 +1,27 @@
+import tw from 'twin.macro';
+import Skeleton from '../../components/atoms/skeleton';
+
+function OutfitItemListSkeleton() {
+  return (
+    <ul>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <li
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          css={[
+            tw`flex-y-center flex-wrap gap-x-2.5 p-3 border-solid border-b `,
+          ]}
+        >
+          <Skeleton width={112} height={112} />
+          <Skeleton width={58} height={30} variant="circular" />
+          <Skeleton height={24} css={[tw`flex-1`]} />
+          <div css={[tw`flex justify-end w-full`]}>
+            <Skeleton width={120} height={24} />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default OutfitItemListSkeleton;

--- a/src/pages/my-scrap-outfit-item/outfit-item-list.tsx
+++ b/src/pages/my-scrap-outfit-item/outfit-item-list.tsx
@@ -1,0 +1,23 @@
+import tw from 'twin.macro';
+import Spinner from '../../components/atoms/spinner';
+import InfiniteScrollFetchTrigger from '../../components/common/infinite-scroll-fetch-trigger';
+import useFetchMyScrapOutfitItemList from '../../hooks/queries/useFetchMyScrapOutfitItemList';
+import OutfitItemListContent from './outfit-item-list-content';
+
+function OutfitItemList() {
+  const { data, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useFetchMyScrapOutfitItemList();
+
+  return (
+    <div>
+      <OutfitItemListContent pagesData={data.pages} />
+      {isFetchingNextPage && <Spinner size={30} css={tw`py-4`} />}
+      <InfiniteScrollFetchTrigger
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+      />
+    </div>
+  );
+}
+
+export default OutfitItemList;

--- a/src/pages/my-scrap/my-scrap-outfit-item-grid.tsx
+++ b/src/pages/my-scrap/my-scrap-outfit-item-grid.tsx
@@ -1,5 +1,77 @@
+import { useNavigate } from 'react-router-dom';
+import tw from 'twin.macro';
+import Spinner from '../../components/atoms/spinner';
+import InfiniteScrollFetchTrigger from '../../components/common/infinite-scroll-fetch-trigger';
+import Grid from '../../components/templates/grid';
+import OutfitScrapButton from '../../features/outfits/outfit-scrap-button';
+import useFetchMyScrapOutfitItemList from '../../hooks/queries/useFetchMyScrapOutfitItemList';
+import { MyScrapOutfitItemListResponse } from '../../types/scrap';
+
+interface GridContentProps {
+  pagesData: Array<MyScrapOutfitItemListResponse>;
+}
+
+function EmptyView() {
+  return (
+    <div className="h-40 flex-center">아직 스크랩한 아이템이 없습니다😶</div>
+  );
+}
+
+function GridContent({ pagesData }: GridContentProps) {
+  const navigate = useNavigate();
+
+  const handleClickGridItem = (outfitItemId: number) => {
+    navigate(`/users/me/scraps/outfit-items/${outfitItemId}`);
+  };
+
+  const isEmpty = pagesData[0].count === 0;
+  if (isEmpty) {
+    return <EmptyView />;
+  }
+
+  return (
+    <Grid>
+      {pagesData.map(({ results: outfitItemList }) =>
+        outfitItemList.map((outfitItem) => (
+          <div
+            key={outfitItem.id}
+            role="gridcell"
+            onClick={() => handleClickGridItem(outfitItem.id)}
+            onKeyDown={() => handleClickGridItem(outfitItem.id)}
+            tabIndex={0}
+            css={[tw`relative cursor-pointer`]}
+          >
+            <img
+              src={outfitItem.imageUrl}
+              alt={outfitItem.name}
+              css={[tw`w-full h-full`]}
+            />
+            <OutfitScrapButton
+              outfitItemId={outfitItem.id}
+              isScrapped={outfitItem.isScrapped}
+              css={[tw`absolute top-0 right-0`]}
+            />
+          </div>
+        ))
+      )}
+    </Grid>
+  );
+}
+
 function MyScrapOutfitItemGrid() {
-  return <div> </div>;
+  const { data, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useFetchMyScrapOutfitItemList();
+
+  return (
+    <div>
+      <GridContent pagesData={data.pages} />
+      {isFetchingNextPage && <Spinner size={30} css={tw`py-4`} />}
+      <InfiniteScrollFetchTrigger
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+      />
+    </div>
+  );
 }
 
 export default MyScrapOutfitItemGrid;

--- a/src/pages/my-scrap/my-scrap-outfit-post-grid.tsx
+++ b/src/pages/my-scrap/my-scrap-outfit-post-grid.tsx
@@ -11,12 +11,23 @@ interface GridContentProps {
   pagesData: Array<MyScrapOutfitPostListResponse>;
 }
 
+function EmptyView() {
+  return (
+    <div className="h-40 flex-center">아직 스크랩한 코디가 없습니다😶</div>
+  );
+}
+
 function GridContent({ pagesData }: GridContentProps) {
   const navigate = useNavigate();
 
   const handleClickGridItem = (outfitPostId: number) => {
     navigate(`/users/me/scraps/outfit-posts/${outfitPostId}`);
   };
+
+  const isEmpty = pagesData[0].count === 0;
+  if (isEmpty) {
+    return <EmptyView />;
+  }
 
   return (
     <Grid>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import HomePage from '../pages/home';
 import LoginPage from '../pages/login';
 import MyScrapPage from '../pages/my-scrap';
+import MyScrapOutfitItemPage from '../pages/my-scrap-outfit-item';
 import MyScrapOutfitPostPage from '../pages/my-scrap-outfit-post';
 import SignupPage from '../pages/signup';
 import RouteWrapper from './route-wrapper';
@@ -32,6 +33,10 @@ const router: RouterType = createBrowserRouter([
       {
         path: '/users/me/scraps/outfit-posts/:outfitPostId',
         element: <MyScrapOutfitPostPage />,
+      },
+      {
+        path: '/users/me/scraps/outfit-items/:outfitItemId',
+        element: <MyScrapOutfitItemPage />,
       },
     ],
   },

--- a/src/types/outfit.ts
+++ b/src/types/outfit.ts
@@ -42,3 +42,12 @@ export type OutfitPostListResponse = PaginationResponse<{
     };
   }[];
 }>;
+
+export type OutfitItemCategory =
+  | '상의'
+  | '하의'
+  | '아우터'
+  | '신발'
+  | '가방'
+  | '악세사리'
+  | '기타';

--- a/src/types/scrap.ts
+++ b/src/types/scrap.ts
@@ -1,8 +1,26 @@
-import { PaginationQueryParams } from './api';
-import { OutfitPostListResponse } from './outfit';
+import { PaginationQueryParams, PaginationResponse } from './api';
+import { OutfitItemCategory, OutfitPostListResponse } from './outfit';
 
 export interface MyScrapOutfitPostListRequest {
   queryParams: PaginationQueryParams;
 }
 
 export type MyScrapOutfitPostListResponse = OutfitPostListResponse;
+
+export interface MyScrapOutfitItemListRequest {
+  queryParams: PaginationQueryParams;
+}
+
+export type MyScrapOutfitItemListResponse = PaginationResponse<{
+  id: number;
+  category: OutfitItemCategory;
+  name: string;
+  purchaseLink?: string;
+  imageUrl: string;
+  scrapCount: number;
+  isScrapped: boolean | null;
+  brand: {
+    id: number;
+    name: string;
+  };
+}>;


### PR DESCRIPTION
# Pull Request
### 작업한 내용
스크랩 페이지의 스크랩한 코디 탭 내부 코디 아이템 그리드와, 그리드 아이템을 눌렀을 경우 나타나는 리스트 페이지를 구현 했습니다.

### 작업 상세 내용
- 스크랩한 코디 아이템 리스트 조회 쿼리 구현
- 스크랩한 코디 아이템 그리드 마크업
- 스크랩한 코드 아이템 그리드 무한 스크롤 구현
- 코디 아이템 스크랩 API 연동
- 스크랩한 코디 아이템 리스트 페이지 구현

### PR Point
- 스크랩한 아이템 페이지에 URL로 접근했을 시 데이터가 불러와지지않아 해당 포스트로 스크롤되지 않는 버그 존재 합니다. 추후 커서 방식으로 변경하면 req cursor에 outfitItemId값을 추가해서 해결 가능합니다.

### 📸 스크린샷
- 스크랩 페이지

![image](https://github.com/user-attachments/assets/92c57568-3671-4c13-824b-e55178e720d5)

- 스크랩한 아이템 페이지

![image](https://github.com/user-attachments/assets/dcba26b3-0950-4d9f-b511-9893f5c65ab0)

closed #64
