### PR TITLE
feat: 코디 생성 페이지 - 셀럽 선택 스텝 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-transition-group": "^4.4.5",
     "storybook-addon-react-router-v6": "^2.0.15",
     "swiper": "^11.1.9",
+    "use-debounce": "^10.0.3",
     "use-query-params": "^2.2.1",
     "zod": "^3.23.8"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "clsx": "^2.1.1",
     "lodash.isnil": "^4.0.0",
     "lodash.omit": "^4.5.0",
+    "path-browserify": "^1.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       lodash.omit:
         specifier: ^4.5.0
         version: 4.5.0
+      path-browserify:
+        specifier: ^1.0.1
+        version: 1.0.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3668,6 +3671,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -8792,6 +8798,8 @@ snapshots:
       lines-and-columns: 1.2.4
 
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       swiper:
         specifier: ^11.1.9
         version: 11.1.9
+      use-debounce:
+        specifier: ^10.0.3
+        version: 10.0.3(react@18.3.1)
       use-query-params:
         specifier: ^2.2.1
         version: 2.2.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.26.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -4572,6 +4575,12 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-debounce@10.0.3:
+    resolution: {integrity: sha512-DxQSI9ZKso689WM1mjgGU3ozcxU1TJElBJ3X6S4SMzMNcm2lVH0AHmyXB+K7ewjz2BSUKJTDqTcwtSMRfB89dg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
 
   use-query-params@2.2.1:
     resolution: {integrity: sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==}
@@ -9746,6 +9755,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-debounce@10.0.3(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.26.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/api/celebrity.ts
+++ b/src/api/celebrity.ts
@@ -1,0 +1,20 @@
+import { axiosInstance } from '../config/axios';
+import type {
+  CelebrityListRequest,
+  CelebrityListResponse,
+} from '../types/celebrity';
+
+export const fetchCelebrities = async (
+  req?: CelebrityListRequest,
+  page?: number
+) => {
+  return (
+    await axiosInstance.get<CelebrityListResponse>('/celebrities', {
+      params: {
+        ...req?.queryParams,
+        page,
+        pageSize: 16,
+      },
+    })
+  ).data;
+};

--- a/src/components/atoms/MoreButton/MoreButton.tsx
+++ b/src/components/atoms/MoreButton/MoreButton.tsx
@@ -1,0 +1,29 @@
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import { ComponentPropsWithoutRef } from 'react';
+import tw from 'twin.macro';
+import { tailwindColors } from '../../../constants/tailwind';
+import Button from '../Button';
+
+interface MoreButtonProps
+  extends Omit<ComponentPropsWithoutRef<typeof Button>, 'children'> {}
+
+function MoreButton({ ...props }: MoreButtonProps) {
+  return (
+    <Button
+      css={[
+        tw`bg-white border-solid border border-gray-700 text-gray-700 disabled:border-none`,
+        {
+          '&:hover&:not([disabled])': {
+            backgroundColor: tailwindColors.gray['200'],
+          },
+        },
+      ]}
+      {...props}
+    >
+      <span>더보기</span>
+      <ExpandMoreRoundedIcon />
+    </Button>
+  );
+}
+
+export default MoreButton;

--- a/src/components/atoms/MoreButton/index.ts
+++ b/src/components/atoms/MoreButton/index.ts
@@ -1,0 +1,3 @@
+import MoreButton from './MoreButton';
+
+export default MoreButton;

--- a/src/components/templates/Layout/LayoutBottomTabBar.tsx
+++ b/src/components/templates/Layout/LayoutBottomTabBar.tsx
@@ -43,7 +43,11 @@ function LayoutBottomTabBar() {
     >
       <TabNavigator icon={<HomeOutlinedIcon />} label="홈" to="/" />
       <TabNavigator icon={<SearchRoundedIcon />} label="검색" to="" />
-      <TabNavigator icon={<AddBoxOutlinedIcon />} label="코디 추가" to="" />
+      <TabNavigator
+        icon={<AddBoxOutlinedIcon />}
+        label="코디 추가"
+        to="/outfit-posts/new"
+      />
       <TabNavigator
         icon={<BookmarkBorderOutlinedIcon />}
         label="스크랩"

--- a/src/components/templates/Layout/LayoutTitleWithCloseAppBar.tsx
+++ b/src/components/templates/Layout/LayoutTitleWithCloseAppBar.tsx
@@ -1,0 +1,35 @@
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { ComponentPropsWithoutRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import tw from 'twin.macro';
+import IconButton from '../../atoms/IconButton';
+
+interface LayoutTitleWithCloseAppBarProps
+  extends ComponentPropsWithoutRef<'div'> {
+  title: string;
+  navigateTo: string;
+}
+
+function LayoutTitleWithCloseAppBar({
+  title,
+  navigateTo,
+}: LayoutTitleWithCloseAppBarProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="custom-app-bar-container" css={[tw`sticky top-0`]}>
+      <span
+        css={[tw`absolute left-1/2 -translate-x-1/2 text-xl font-semibold`]}
+      >
+        {title}
+      </span>
+      <IconButton
+        icon={<CloseRoundedIcon />}
+        onClick={() => navigate(navigateTo)}
+        css={[tw`ml-auto`]}
+      />
+    </div>
+  );
+}
+
+export default LayoutTitleWithCloseAppBar;

--- a/src/components/templates/Layout/index.ts
+++ b/src/components/templates/Layout/index.ts
@@ -1,11 +1,13 @@
-import LayoutBottomTabBar from './LayoutBottomTabBar';
 import LayoutMain from './Layout';
+import LayoutBottomTabBar from './LayoutBottomTabBar';
 import LayoutLogoAppBar from './LayoutLogoAppBar';
 import LayoutTitleWithBackAppBar from './LayoutTitleWithBackAppBar';
+import LayoutTitleWithCloseAppBar from './LayoutTitleWithCloseAppBar';
 
 const Layout = Object.assign(LayoutMain, {
   LogoAppBar: LayoutLogoAppBar,
   TitleWithBackAppBar: LayoutTitleWithBackAppBar,
+  TitleWithCloseAppBar: LayoutTitleWithCloseAppBar,
   BottomTabBar: LayoutBottomTabBar,
 });
 

--- a/src/constants/file.ts
+++ b/src/constants/file.ts
@@ -1,0 +1,12 @@
+export const KB = 1024;
+export const MB = 1024 * KB;
+export const ALLOWED_EXTENSIONS = [
+  'jpg',
+  'jpeg',
+  'jfif',
+  'png',
+  'bmp',
+  'webp',
+  'tif',
+  'tiff',
+] as const;

--- a/src/features/celebrities/queries/useFetchCelebrityList.ts
+++ b/src/features/celebrities/queries/useFetchCelebrityList.ts
@@ -1,0 +1,14 @@
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { fetchCelebrities } from '../../../api/celebrity';
+import { CelebrityListRequest } from '../../../types/celebrity';
+
+const useFetchCelebrityList = (req?: CelebrityListRequest) => {
+  return useSuspenseInfiniteQuery({
+    queryKey: ['fetchCelebrityList', req],
+    queryFn: ({ pageParam }) => fetchCelebrities(req, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: ({ next }) => next,
+  });
+};
+
+export default useFetchCelebrityList;

--- a/src/features/outfits/components/OutfitFeed/OutfitPost/OutfitPostSlider/OutfitPostSlider.tsx
+++ b/src/features/outfits/components/OutfitFeed/OutfitPost/OutfitPostSlider/OutfitPostSlider.tsx
@@ -24,7 +24,7 @@ function OutfitPostSlider({ outfitPost, ...props }: OutfitPostSliderProps) {
       >
         <SwiperSlide>
           <OutfitPostSliderImage
-            src={outfitPost.imageUrl}
+            src={outfitPost.image}
             alt={outfitPost.title}
           />
           <OutfitPostSliderInfo

--- a/src/hooks/useFunnel/Funnel.tsx
+++ b/src/hooks/useFunnel/Funnel.tsx
@@ -1,0 +1,29 @@
+import { ReactElement, ReactNode } from 'react';
+
+export interface FunnelProps<StepType> {
+  children:
+    | Array<ReactElement<StepProps<StepType>>>
+    | ReactElement<StepProps<StepType>>;
+}
+
+export interface StepProps<StepType> {
+  name: StepType;
+  activeStep: StepType;
+  children: ReactNode;
+}
+
+export function Step<StepType>({
+  name,
+  activeStep,
+  children,
+}: StepProps<StepType>) {
+  if (name !== activeStep) {
+    return null;
+  }
+
+  return children;
+}
+
+export function Funnel<StepType>({ children }: FunnelProps<StepType>) {
+  return children;
+}

--- a/src/hooks/useFunnel/index.ts
+++ b/src/hooks/useFunnel/index.ts
@@ -1,0 +1,3 @@
+import useFunnel from './useFunnel';
+
+export default useFunnel;

--- a/src/hooks/useFunnel/useFunnel.tsx
+++ b/src/hooks/useFunnel/useFunnel.tsx
@@ -1,0 +1,42 @@
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+import {
+  Funnel as FunnelComponent,
+  Step as StepComponent,
+  StepProps,
+} from './Funnel';
+
+/**
+ * 퍼넬 스텝에 맞게 UI를 보여주고 스텝의 라우트 히스토리를 관리 해주는 Hook 입니다.
+ * 정확한 타입 추론을 위해 반드시 `steps`는 as const를 사용해 객체 리터럴로 인자가 전달되어야 합니다.
+ *
+ * @example
+ *
+ * ```tsx
+ * const { Funnel, setStep } = useFunnel(['스텝1', '스텝2'] as const)
+ * ```
+ */
+const useFunnel = <T extends Array<string>>(steps: T) => {
+  type StepType = T[number];
+
+  const [step, setStep] = useQueryParam(
+    'step',
+    withDefault(StringParam, steps[0])
+  ) as [StepType, (step: StepType) => void];
+
+  function StepRenderer({
+    children,
+    name,
+  }: Omit<StepProps<StepType>, 'activeStep'>) {
+    return (
+      <StepComponent<StepType> name={name} activeStep={step}>
+        {children}
+      </StepComponent>
+    );
+  }
+
+  const Funnel = Object.assign(FunnelComponent, { Step: StepRenderer });
+
+  return { Funnel, setStep };
+};
+
+export default useFunnel;

--- a/src/mocks/datas/outfit-feed.ts
+++ b/src/mocks/datas/outfit-feed.ts
@@ -19,7 +19,7 @@ const mockOutfitFeed = {
           title: '장원영 사복 패션',
           createdAt: '2024-08-07T02:00:16.690393+09:00',
           gender: '여성',
-          imageUrl: post1Image,
+          image: post1Image,
           scrapCount: 0,
           isScrapped: null,
           celebrity: {
@@ -52,7 +52,7 @@ const mockOutfitFeed = {
           title: '피오 봄 코디',
           createdAt: '2024-07-29T14:05:12.561135+09:00',
           gender: '남성',
-          imageUrl: post2Image,
+          image: post2Image,
           scrapCount: 0,
           isScrapped: null,
           celebrity: {

--- a/src/pages/CreateOutfitPostPage/CreateOutfitPostPage.tsx
+++ b/src/pages/CreateOutfitPostPage/CreateOutfitPostPage.tsx
@@ -1,0 +1,16 @@
+import Layout from '../../components/templates/Layout';
+import CreateOutfitPostFunnel from './components/CreateOutfitPostFunnel';
+import { CreateOutfitPostPageProvider } from './CreateOutfitPostPageProvider';
+
+function CreateOutfitPostPage() {
+  return (
+    <CreateOutfitPostPageProvider>
+      <Layout>
+        <Layout.TitleWithCloseAppBar title="코디 추가" navigateTo="/" />
+        <CreateOutfitPostFunnel />
+      </Layout>
+    </CreateOutfitPostPageProvider>
+  );
+}
+
+export default CreateOutfitPostPage;

--- a/src/pages/CreateOutfitPostPage/CreateOutfitPostPageProvider.tsx
+++ b/src/pages/CreateOutfitPostPage/CreateOutfitPostPageProvider.tsx
@@ -1,0 +1,36 @@
+import { createContext, ReactNode, useMemo } from 'react';
+import useCreateOutfitPostForm from './useCreateOutfitPostForm';
+import useCreateOutfitPostFunnel from './useCreateOutfitPostFunnel';
+
+type CreateOutfitPostPageContextType = ReturnType<
+  typeof useCreateOutfitPostForm
+> &
+  ReturnType<typeof useCreateOutfitPostFunnel>;
+
+export const CreateOutfitPostPageContext =
+  createContext<CreateOutfitPostPageContextType | null>(null);
+
+interface CreateOutfitPostPageProviderProps {
+  children: ReactNode;
+}
+
+export function CreateOutfitPostPageProvider({
+  children,
+}: CreateOutfitPostPageProviderProps) {
+  const formController = useCreateOutfitPostForm();
+  const funnelController = useCreateOutfitPostFunnel();
+
+  const value = useMemo(
+    () => ({
+      ...formController,
+      ...funnelController,
+    }),
+    [formController, funnelController]
+  );
+
+  return (
+    <CreateOutfitPostPageContext.Provider value={value}>
+      {children}
+    </CreateOutfitPostPageContext.Provider>
+  );
+}

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityList.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityList.tsx
@@ -1,0 +1,48 @@
+import { useSearchParams } from 'react-router-dom';
+import tw from 'twin.macro';
+import { useDebounce } from 'use-debounce';
+import MoreButton from '../../../../components/atoms/MoreButton';
+import Spinner from '../../../../components/atoms/Spinner';
+import useFetchCelebrityList from '../../../../features/celebrities/queries/useFetchCelebrityList';
+import { CelebrityCategory } from '../../../../types/celebrity';
+import { OutfitPostListRequest } from '../../../../types/outfit';
+import CelebrityListContent from './CelebrityListContent';
+
+interface CelebrityListProps {
+  search: string | undefined;
+}
+
+function CelebrityList({ search }: CelebrityListProps) {
+  const [searchParams] = useSearchParams();
+  const celebrityCategory = searchParams.get(
+    'celebrityCategory'
+  ) as CelebrityCategory;
+
+  const [debouncedSearch] = useDebounce(search, 300);
+
+  const req: OutfitPostListRequest = {
+    queryParams: {
+      celebrityCategory,
+      search: debouncedSearch,
+    },
+  };
+
+  const { data, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useFetchCelebrityList(req);
+
+  return (
+    <div css={[tw`flex flex-col items-center w-full max-w-[420px]`]}>
+      <CelebrityListContent pagesData={data.pages} />
+      {isFetchingNextPage && <Spinner size={30} css={tw`py-4`} />}
+      {hasNextPage && (
+        <MoreButton
+          disabled={isFetchingNextPage}
+          onClick={() => fetchNextPage()}
+          css={[tw`w-60 mt-10`]}
+        />
+      )}
+    </div>
+  );
+}
+
+export default CelebrityList;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityListContent.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityListContent.tsx
@@ -1,0 +1,39 @@
+import { useId } from 'react';
+import tw from 'twin.macro';
+import { CelebrityListResponse } from '../../../../types/celebrity';
+import CelebrityListContentItem from './CelebrityListContentItem';
+
+interface CelebrityListContentProps {
+  pagesData: Array<CelebrityListResponse>;
+}
+
+function EmptyView() {
+  return (
+    <div className="h-40 flex-center">관련 셀럽이 존재하지 않습니다😥</div>
+  );
+}
+
+function CelebrityListContent({ pagesData }: CelebrityListContentProps) {
+  const celebrityRadioGroupId = useId();
+
+  const isEmpty = pagesData[0].count === 0;
+  if (isEmpty) {
+    return <EmptyView />;
+  }
+
+  return (
+    <div css={[tw`grid grid-cols-4 gap-4 w-full`]}>
+      {pagesData.map(({ results: celebrityList }) =>
+        celebrityList.map((celebrity) => (
+          <CelebrityListContentItem
+            key={celebrity.id}
+            celebrity={celebrity}
+            celebrityRadioGroupId={celebrityRadioGroupId}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+export default CelebrityListContent;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityListContentItem.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityListContentItem.tsx
@@ -1,0 +1,54 @@
+import { useId } from 'react';
+import tw from 'twin.macro';
+import Avatar from '../../../../components/atoms/Avatar';
+import { CelebrityListResponse } from '../../../../types/celebrity';
+import useCreateOutfitPostPageContext from '../../useCreateOutfitPostPageContext';
+
+interface CelebrityListContentItemProps {
+  celebrityRadioGroupId: string;
+  celebrity: CelebrityListResponse['results'][number];
+}
+
+function CelebrityListContentItem({
+  celebrityRadioGroupId,
+  celebrity,
+}: CelebrityListContentItemProps) {
+  const CelebrityItemId = useId();
+
+  const {
+    celebrityId: { onChange, value },
+  } = useCreateOutfitPostPageContext();
+
+  const isSelected = Number(value) === celebrity.id;
+
+  return (
+    <label
+      key={celebrity.id}
+      htmlFor={CelebrityItemId}
+      css={[
+        tw`relative flex-y-center flex-col gap-y-2 cursor-pointer rounded font-medium`,
+        tw`hover:text-indigo-500 hover:font-semibold`,
+        isSelected && tw`text-indigo-500 font-semibold`,
+      ]}
+    >
+      <Avatar
+        src={celebrity.profileImageUrl}
+        size={70}
+        alt={`${celebrity.name} 프로필 이미지`}
+        css={[isSelected && tw`border-solid border-2 border-indigo-500`]}
+      />
+      <span css={[tw`text-center line-clamp-2`]}>{celebrity.name}</span>
+      <input
+        type="radio"
+        name={celebrityRadioGroupId}
+        value={celebrity.id}
+        onChange={onChange}
+        checked={isSelected}
+        id={CelebrityItemId}
+        css={[tw`hidden`]}
+      />
+    </label>
+  );
+}
+
+export default CelebrityListContentItem;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityListSkeleton.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebrityListSkeleton.tsx
@@ -1,0 +1,18 @@
+import tw from 'twin.macro';
+import Skeleton from '../../../../components/atoms/Skeleton';
+
+function CelebrityListSkeleton() {
+  return (
+    <div css={[tw`grid grid-cols-4 gap-4 w-full max-w-[420px]`]}>
+      {Array.from({ length: 16 }).map((_, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={i} css={[tw`flex-center flex-col gap-y-2`]}>
+          <Skeleton variant="circular" width={70} height={70} css={[tw``]} />
+          <Skeleton variant="rectangular" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default CelebrityListSkeleton;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebritySearchBar.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CelebritySearchBar.tsx
@@ -1,0 +1,41 @@
+import RestartAltRoundedIcon from '@mui/icons-material/RestartAltRounded';
+import { Dispatch, SetStateAction } from 'react';
+import tw from 'twin.macro';
+import Button from '../../../../components/atoms/Button';
+import TextField from '../../../../components/atoms/TextField';
+import CelebrityCategorySelect from '../../../../features/celebrities/components/CelebrityCategorySelect';
+import useCreateOutfitPostPageContext from '../../useCreateOutfitPostPageContext';
+
+interface CelebritySearchBarProps {
+  search: string | undefined;
+  setSearch: Dispatch<SetStateAction<string | undefined>>;
+}
+
+function CelebritySearchBar({ search, setSearch }: CelebritySearchBarProps) {
+  const { resetField } = useCreateOutfitPostPageContext();
+
+  return (
+    <div css={[tw`flex-y-center flex-wrap gap-4 mb-10`]}>
+      <CelebrityCategorySelect />
+      <TextField
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+        label="검색"
+        css={[tw`flex-1`]}
+      />
+      <div css={[tw`w-full`]}>
+        <Button
+          color="indigo"
+          size="small"
+          onClick={() => resetField('celebrityId')}
+          css={[tw`ml-auto`]}
+        >
+          <span css={[tw`mr-1`]}>선택 초기화</span>
+          <RestartAltRoundedIcon fontSize="small" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default CelebritySearchBar;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep.tsx
@@ -1,0 +1,42 @@
+import { Suspense, useState } from 'react';
+import tw from 'twin.macro';
+import Button from '../../../../components/atoms/Button';
+import LocalApiErrorBoundary from '../../../../components/errors/LocalApiErrorBoundary';
+import useCreateOutfitPostPageContext from '../../useCreateOutfitPostPageContext';
+import CreateOutfitPostProgress from '../CreateOutfitPostProgress';
+import CreateOutfitPostTitle from '../CreateOutfitPostTitle';
+import CelebrityList from './CelebrityList';
+import CelebrityListSkeleton from './CelebrityListSkeleton';
+import CelebritySearchBar from './CelebritySearchBar';
+
+function CreateOutfitPostCelebrityStep() {
+  const { Funnel, setStep, celebrityId } = useCreateOutfitPostPageContext();
+  const [search, setSearch] = useState<string>();
+
+  return (
+    <Funnel.Step name="celebrity">
+      <div css={[tw`flex flex-col items-center px-4`]}>
+        <CreateOutfitPostProgress stepNumber={1} />
+        <CreateOutfitPostTitle>
+          코디에 맞는 셀럽을
+          <br /> 선택해 주세요.
+        </CreateOutfitPostTitle>
+        <CelebritySearchBar search={search} setSearch={setSearch} />
+        <LocalApiErrorBoundary>
+          <Suspense fallback={<CelebrityListSkeleton />}>
+            <CelebrityList search={search} />
+          </Suspense>
+        </LocalApiErrorBoundary>
+        <Button
+          disabled={!celebrityId.value}
+          onClick={() => setStep('gender')}
+          css={[tw`mt-20 w-1/2`]}
+        >
+          다음으로
+        </Button>
+      </div>
+    </Funnel.Step>
+  );
+}
+
+export default CreateOutfitPostCelebrityStep;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/index.ts
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/index.ts
@@ -1,0 +1,3 @@
+import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep';
+
+export default CreateOutfitPostCelebrityStep;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -1,0 +1,12 @@
+import useCreateOutfitPostPageContext from '../useCreateOutfitPostPageContext';
+
+function CreateOutfitPostFunnel() {
+  const { Funnel } = useCreateOutfitPostPageContext();
+
+  return (
+    <Funnel>
+    </Funnel>
+  );
+}
+
+export default CreateOutfitPostFunnel;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -1,10 +1,12 @@
 import useCreateOutfitPostPageContext from '../useCreateOutfitPostPageContext';
+import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep';
 
 function CreateOutfitPostFunnel() {
   const { Funnel } = useCreateOutfitPostPageContext();
 
   return (
     <Funnel>
+      <CreateOutfitPostCelebrityStep />
     </Funnel>
   );
 }

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostProgress.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostProgress.tsx
@@ -1,0 +1,53 @@
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import tw from 'twin.macro';
+
+interface CreateOutfitPostProgressProps {
+  stepNumber: number;
+}
+
+function ProgressLine({
+  level,
+  stepNumber,
+}: CreateOutfitPostProgressProps & { level: number }) {
+  return (
+    <div
+      css={[
+        tw`w-full h-1 px-5 bg-gray-300`,
+        stepNumber - 1 > level && tw`bg-indigo-500`,
+      ]}
+    />
+  );
+}
+
+function ProgressIcon({
+  level,
+  stepNumber,
+}: CreateOutfitPostProgressProps & { level: number }) {
+  return (
+    <CheckCircleRoundedIcon css={[stepNumber > level && tw`text-indigo-500`]} />
+  );
+}
+
+function CreateOutfitPostProgress({
+  stepNumber,
+}: CreateOutfitPostProgressProps) {
+  return (
+    <div css={[tw`relative flex-y-center w-full pt-4 text-gray-300`]}>
+      <ProgressIcon stepNumber={stepNumber} level={1} />
+      <ProgressLine stepNumber={stepNumber} level={1} />
+
+      <ProgressIcon stepNumber={stepNumber} level={2} />
+      <ProgressLine stepNumber={stepNumber} level={2} />
+
+      <ProgressIcon stepNumber={stepNumber} level={3} />
+      <ProgressLine stepNumber={stepNumber} level={3} />
+
+      <ProgressIcon stepNumber={stepNumber} level={4} />
+      <ProgressLine stepNumber={stepNumber} level={4} />
+
+      <ProgressIcon stepNumber={stepNumber} level={5} />
+    </div>
+  );
+}
+
+export default CreateOutfitPostProgress;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostTitle.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostTitle.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import tw from 'twin.macro';
+
+interface CreateOutfitPostTitleProps {
+  children: ReactNode;
+}
+
+function CreateOutfitPostTitle({ children }: CreateOutfitPostTitleProps) {
+  return <h1 css={[tw`text-center text-2xl font-medium py-14`]}>{children}</h1>;
+}
+
+export default CreateOutfitPostTitle;

--- a/src/pages/CreateOutfitPostPage/index.ts
+++ b/src/pages/CreateOutfitPostPage/index.ts
@@ -1,0 +1,3 @@
+import CreateOutfitPostPage from './CreateOutfitPostPage';
+
+export default CreateOutfitPostPage;

--- a/src/pages/CreateOutfitPostPage/useCreateOutfitPostForm.ts
+++ b/src/pages/CreateOutfitPostPage/useCreateOutfitPostForm.ts
@@ -1,0 +1,76 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useController, useForm } from 'react-hook-form';
+import { z, ZodType } from 'zod';
+import { fileSchema } from '../../schemas/file';
+import { CreateOutfitPostRequest } from '../../types/outfit';
+
+const schema = z.object({
+  celebrityId: z.number({ message: '코디에 맞는 셀럽을 선택해 주세요.' }),
+  gender: z.union([z.literal('남성'), z.literal('여성'), z.literal('공용')], {
+    message: '코디에 맞는 성별을 선택해 주세요.',
+  }),
+  title: z
+    .string()
+    .min(1, { message: '코디 제목을 입력해 주세요.' })
+    .min(4, { message: '코디 제목은 4자 이상이어야 합니다.' })
+    .max(12, { message: '코디 제목은 20자 이하여야 합니다.' }),
+  image: fileSchema({
+    requiredMessage: '코디 이미지를 업로드해 주세요.',
+  }),
+  itemIds: z
+    .array(z.number())
+    .nonempty({ message: '코디 아이템을 선택해 주세요.' })
+    .max(5, { message: '코디 아이템은 5개 이하여야 합니다.' }),
+}) satisfies ZodType<CreateOutfitPostRequest['payload']>;
+
+const useCreateOutfitPostForm = () => {
+  const {
+    control,
+    handleSubmit,
+    resetField,
+    formState: { errors },
+  } = useForm<CreateOutfitPostRequest['payload']>({
+    resolver: zodResolver(schema),
+  });
+
+  const { field: celebrityId } = useController({
+    name: 'celebrityId',
+    control,
+  });
+
+  const { field: gender } = useController({
+    name: 'gender',
+    defaultValue: '남성',
+    control,
+  });
+
+  const { field: title } = useController({
+    name: 'title',
+    defaultValue: '',
+    control,
+  });
+
+  const { field: image } = useController({
+    name: 'image',
+    control,
+  });
+
+  const { field: itemIds } = useController({
+    name: 'itemIds',
+    defaultValue: [],
+    control,
+  });
+
+  return {
+    handleSubmit,
+    resetField,
+    errors,
+    celebrityId,
+    gender,
+    title,
+    image,
+    itemIds,
+  };
+};
+
+export default useCreateOutfitPostForm;

--- a/src/pages/CreateOutfitPostPage/useCreateOutfitPostFunnel.ts
+++ b/src/pages/CreateOutfitPostPage/useCreateOutfitPostFunnel.ts
@@ -1,0 +1,13 @@
+import useFunnel from '../../hooks/useFunnel';
+
+const useCreateOutfitPostFunnel = () => {
+  return useFunnel([
+    'celebrity',
+    'gender',
+    'title',
+    'outfitPostImage',
+    'outfitItems',
+  ] as const);
+};
+
+export default useCreateOutfitPostFunnel;

--- a/src/pages/CreateOutfitPostPage/useCreateOutfitPostPageContext.ts
+++ b/src/pages/CreateOutfitPostPage/useCreateOutfitPostPageContext.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { CreateOutfitPostPageContext } from './CreateOutfitPostPageProvider';
+
+const useCreateOutfitPostPageContext = () => {
+  const context = useContext(CreateOutfitPostPageContext);
+
+  if (!context) {
+    throw Error(
+      'CreateOutfitPostPageContext는 CreateOutfitPostPage 페이지 내부에서만 사용할 수 있습니다.'
+    );
+  }
+
+  return context;
+};
+
+export default useCreateOutfitPostPageContext;

--- a/src/pages/MyScrapPage/components/MyScrapOutfitPostGrid.tsx
+++ b/src/pages/MyScrapPage/components/MyScrapOutfitPostGrid.tsx
@@ -42,7 +42,7 @@ function GridContent({ pagesData }: GridContentProps) {
             css={[tw`relative cursor-pointer`]}
           >
             <img
-              src={outfitPost.imageUrl}
+              src={outfitPost.image}
               alt={outfitPost.title}
               css={[tw`w-full h-full`]}
             />

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import CreateOutfitPostPage from '../pages/CreateOutfitPostPage';
 import HomePage from '../pages/HomePage';
 import LoginPage from '../pages/LoginPage';
 import MyScrapOutfitItemPage from '../pages/MyScrapOutfitItemPage';
@@ -37,6 +38,10 @@ const router: RouterType = createBrowserRouter([
       {
         path: '/users/me/scraps/outfit-items/:outfitItemId',
         element: <MyScrapOutfitItemPage />,
+      },
+      {
+        path: '/outfit-posts/new',
+        element: <CreateOutfitPostPage />,
       },
     ],
   },

--- a/src/schemas/file.ts
+++ b/src/schemas/file.ts
@@ -1,0 +1,36 @@
+import { extname } from 'path';
+import { z } from 'zod';
+import { ALLOWED_EXTENSIONS, MB } from '../constants/file';
+
+interface FileSchemaParams {
+  requiredMessage: string;
+  /**
+   * MB 단위 파일 사이즈 입니다.
+   */
+  maxSizeMB?: number;
+}
+
+const checkExtension = (file: File) => {
+  const extensionName = extname(file.name); // 확장자명('.' 포함)
+
+  const extensionPattern = `\\.(${ALLOWED_EXTENSIONS.join('|')})$`;
+  const regex = RegExp(extensionPattern, 'i');
+
+  return regex.test(extensionName);
+};
+
+export const fileSchema = ({
+  requiredMessage,
+  maxSizeMB = 2.5,
+}: FileSchemaParams) => {
+  return z
+    .instanceof(File, { message: requiredMessage })
+    .refine(
+      (file) => file.size < maxSizeMB * MB,
+      `파일 크기는 ${maxSizeMB}MB 미만이어야 합니다.`
+    )
+    .refine(
+      (file) => checkExtension(file),
+      `${ALLOWED_EXTENSIONS.join(', ')} 확장자만 업로드할 수 있습니다.`
+    );
+};

--- a/src/types/celebrity.ts
+++ b/src/types/celebrity.ts
@@ -1,3 +1,5 @@
+import { PaginationQueryParams, PaginationResponse } from './api';
+
 export type CelebrityCategory =
   | '아이돌'
   | '모델'
@@ -5,3 +7,16 @@ export type CelebrityCategory =
   | '배우'
   | '인플루언서'
   | '기타';
+
+export interface CelebrityListRequest {
+  queryParams: {
+    category?: CelebrityCategory | null;
+    search?: string | null;
+  } & PaginationQueryParams;
+}
+
+export type CelebrityListResponse = PaginationResponse<{
+  id: number;
+  name: string;
+  profileImageUrl: string;
+}>;

--- a/src/types/outfit.ts
+++ b/src/types/outfit.ts
@@ -51,3 +51,13 @@ export type OutfitItemCategory =
   | '가방'
   | '악세사리'
   | '기타';
+
+export interface CreateOutfitPostRequest {
+  payload: {
+    celebrityId: number;
+    gender: OutfitPostGender;
+    title: string;
+    image: File;
+    itemIds: number[];
+  };
+}

--- a/src/types/outfit.ts
+++ b/src/types/outfit.ts
@@ -17,7 +17,7 @@ export type OutfitPostListResponse = PaginationResponse<{
   title: string;
   createdAt: string;
   gender: OutfitPostGender;
-  imageUrl: string;
+  image: string;
   scrapCount: number;
   isScrapped: boolean | null;
   celebrity: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,9 @@ export default defineConfig({
       },
     }),
   ],
+  resolve: {
+    alias: {
+      path: 'path-browserify',
+    },
+  },
 });


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 코디 생성 페이지 Funnel에서 셀럽 선택 스텝 컴포넌트를 구현 했습니다.

### 상세 작업 내역
- LayoutTitleWithBackAppBar 컴포넌트 추가
- useFunnel 구현
- 코디 생성 페이지 form 훅, context 훅 구현 및 적용
- 셀럽 리스트 조회 쿼리 구현
- MoreButton 컴포넌트 구현
- 스텝 컴포넌트 마크업

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/650fd6df-687f-45ca-bd2a-f28f2ccdf8e8)

closed #77
