### PR TITLE
feat: 코디 생성 페이지 - 성별 선택 스텝 구현

### DIFF
--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep.tsx
@@ -15,22 +15,22 @@ function CreateOutfitPostCelebrityStep() {
 
   return (
     <Funnel.Step name="celebrity">
-      <div css={[tw`flex flex-col items-center px-4`]}>
-        <CreateOutfitPostProgress stepNumber={1} />
-        <CreateOutfitPostTitle>
-          코디에 맞는 셀럽을
-          <br /> 선택해 주세요.
-        </CreateOutfitPostTitle>
-        <CelebritySearchBar search={search} setSearch={setSearch} />
-        <LocalApiErrorBoundary>
-          <Suspense fallback={<CelebrityListSkeleton />}>
-            <CelebrityList search={search} />
-          </Suspense>
-        </LocalApiErrorBoundary>
+      <CreateOutfitPostProgress stepNumber={1} />
+      <CreateOutfitPostTitle>
+        코디에 맞는 셀럽을
+        <br /> 선택해 주세요.
+      </CreateOutfitPostTitle>
+      <CelebritySearchBar search={search} setSearch={setSearch} />
+      <LocalApiErrorBoundary>
+        <Suspense fallback={<CelebrityListSkeleton />}>
+          <CelebrityList search={search} />
+        </Suspense>
+      </LocalApiErrorBoundary>
+      <div css={[tw`sticky w-full mt-auto pt-8`]}>
         <Button
+          fullWidth
           disabled={!celebrityId.value}
           onClick={() => setStep('gender')}
-          css={[tw`mt-20 w-1/2`]}
         >
           다음으로
         </Button>

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -1,13 +1,16 @@
+import tw from 'twin.macro';
 import useCreateOutfitPostPageContext from '../useCreateOutfitPostPageContext';
-import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep';
+import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep';
 
 function CreateOutfitPostFunnel() {
   const { Funnel } = useCreateOutfitPostPageContext();
 
   return (
-    <Funnel>
-      <CreateOutfitPostCelebrityStep />
-    </Funnel>
+    <div css={[tw`flex flex-col items-center flex-1 p-4 pb-6`]}>
+      <Funnel>
+        <CreateOutfitPostCelebrityStep />
+      </Funnel>
+    </div>
   );
 }
 

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -1,6 +1,7 @@
 import tw from 'twin.macro';
 import useCreateOutfitPostPageContext from '../useCreateOutfitPostPageContext';
 import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep';
+import CreateOutfitPostGenderStep from './CreateOutfitPostGenderStep';
 
 function CreateOutfitPostFunnel() {
   const { Funnel } = useCreateOutfitPostPageContext();
@@ -9,6 +10,7 @@ function CreateOutfitPostFunnel() {
     <div css={[tw`flex flex-col items-center flex-1 p-4 pb-6`]}>
       <Funnel>
         <CreateOutfitPostCelebrityStep />
+        <CreateOutfitPostGenderStep />
       </Funnel>
     </div>
   );

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/CreateOutfitPostGenderStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/CreateOutfitPostGenderStep.tsx
@@ -1,0 +1,38 @@
+import tw from 'twin.macro';
+import Button from '../../../../components/atoms/Button';
+import useCreateOutfitPostPageContext from '../../useCreateOutfitPostPageContext';
+import CreateOutfitPostProgress from '../CreateOutfitPostProgress';
+import CreateOutfitPostTitle from '../CreateOutfitPostTitle';
+import OutfitPostGenderRadioGroup from './OutfitPostGenderRadioGroup';
+
+function CreateOutfitPostGenderStep() {
+  const { Funnel, setStep, gender } = useCreateOutfitPostPageContext();
+
+  return (
+    <Funnel.Step name="gender">
+      <CreateOutfitPostProgress stepNumber={2} />
+      <CreateOutfitPostTitle>
+        코디에 맞는 성별을
+        <br /> 선택해 주세요.
+      </CreateOutfitPostTitle>
+      <OutfitPostGenderRadioGroup
+        value={gender.value}
+        onChange={gender.onChange}
+      />
+      <div css={[tw`sticky bottom-0 flex gap-x-6 w-full mt-auto`]}>
+        <Button fullWidth color="gray" onClick={() => setStep('celebrity')}>
+          이전으로
+        </Button>
+        <Button
+          fullWidth
+          disabled={!gender.value}
+          onClick={() => setStep('outfitPostImage')}
+        >
+          다음으로
+        </Button>
+      </div>
+    </Funnel.Step>
+  );
+}
+
+export default CreateOutfitPostGenderStep;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/OutfitPostGenderRadioGroup.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/OutfitPostGenderRadioGroup.tsx
@@ -1,0 +1,33 @@
+import { ChangeEventHandler } from 'react';
+import tw from 'twin.macro';
+import RadioGroup from '../../../../components/atoms/RadioGroup';
+import { RadioGroupOptionsType } from '../../../../components/atoms/RadioGroup/types';
+import { OutfitPostGender } from '../../../../types/outfit';
+
+interface OutfitPostGenderRadioGroupProps {
+  value: OutfitPostGender;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+}
+
+const options: RadioGroupOptionsType<OutfitPostGender> = [
+  { value: '남성' },
+  { value: '여성' },
+  { value: '공용' },
+];
+
+function OutfitPostGenderRadioGroup({
+  value,
+  onChange,
+}: OutfitPostGenderRadioGroupProps) {
+  return (
+    <RadioGroup
+      value={value}
+      onChange={onChange}
+      label="성별"
+      options={options}
+      css={[tw`w-80`]}
+    />
+  );
+}
+
+export default OutfitPostGenderRadioGroup;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/index.ts
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/index.ts
@@ -1,0 +1,3 @@
+import CreateOutfitPostGenderStep from './CreateOutfitPostGenderStep';
+
+export default CreateOutfitPostGenderStep;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostProgress.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostProgress.tsx
@@ -32,7 +32,7 @@ function CreateOutfitPostProgress({
   stepNumber,
 }: CreateOutfitPostProgressProps) {
   return (
-    <div css={[tw`relative flex-y-center w-full pt-4 text-gray-300`]}>
+    <div css={[tw`relative flex-y-center w-full text-gray-300`]}>
       <ProgressIcon stepNumber={stepNumber} level={1} />
       <ProgressLine stepNumber={stepNumber} level={1} />
 


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 코디 생성 페이지 Funnel에서 성별 선택 스텝 컴포넌트를 구현 했습니다.

### 상세 작업 내역
- Funnel 컨테이너 스타일 적용
- 성별 선택 스텝 컴포넌트 구현

### PR Point
- 추후 더 나은 UI를 위해 RadioGroup이 아닌 사이즈가 큰 버튼 세개를 클릭(터치)하는 식으로 개선할 수 있습니다.

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/05d820fd-62ab-4d04-af8e-59f9f4679b1c)

closed #79
