### PR TITLE
feat: 코디 생성 페이지 - 코디 제목 입력 스텝 구현

### DIFF
--- a/src/pages/CreateOutfitPostPage/CreateOutfitPostPageProvider.tsx
+++ b/src/pages/CreateOutfitPostPage/CreateOutfitPostPageProvider.tsx
@@ -1,11 +1,9 @@
-import { createContext, ReactNode, useMemo } from 'react';
+import { createContext, ReactNode } from 'react';
 import useCreateOutfitPostForm from './useCreateOutfitPostForm';
-import useCreateOutfitPostFunnel from './useCreateOutfitPostFunnel';
 
 type CreateOutfitPostPageContextType = ReturnType<
   typeof useCreateOutfitPostForm
-> &
-  ReturnType<typeof useCreateOutfitPostFunnel>;
+>;
 
 export const CreateOutfitPostPageContext =
   createContext<CreateOutfitPostPageContextType | null>(null);
@@ -17,19 +15,8 @@ interface CreateOutfitPostPageProviderProps {
 export function CreateOutfitPostPageProvider({
   children,
 }: CreateOutfitPostPageProviderProps) {
-  const formController = useCreateOutfitPostForm();
-  const funnelController = useCreateOutfitPostFunnel();
-
-  const value = useMemo(
-    () => ({
-      ...formController,
-      ...funnelController,
-    }),
-    [formController, funnelController]
-  );
-
   return (
-    <CreateOutfitPostPageContext.Provider value={value}>
+    <CreateOutfitPostPageContext.Provider value={useCreateOutfitPostForm()}>
       {children}
     </CreateOutfitPostPageContext.Provider>
   );

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostCelebrityStep/CreateOutfitPostCelebrityStep.tsx
@@ -9,12 +9,18 @@ import CelebrityList from './CelebrityList';
 import CelebrityListSkeleton from './CelebrityListSkeleton';
 import CelebritySearchBar from './CelebritySearchBar';
 
-function CreateOutfitPostCelebrityStep() {
-  const { Funnel, setStep, celebrityId } = useCreateOutfitPostPageContext();
+interface CreateOutfitPostCelebrityStepProps {
+  onClickNext: () => void;
+}
+
+function CreateOutfitPostCelebrityStep({
+  onClickNext,
+}: CreateOutfitPostCelebrityStepProps) {
+  const { celebrityId } = useCreateOutfitPostPageContext();
   const [search, setSearch] = useState<string>();
 
   return (
-    <Funnel.Step name="celebrity">
+    <>
       <CreateOutfitPostProgress stepNumber={1} />
       <CreateOutfitPostTitle>
         코디에 맞는 셀럽을
@@ -27,15 +33,11 @@ function CreateOutfitPostCelebrityStep() {
         </Suspense>
       </LocalApiErrorBoundary>
       <div css={[tw`sticky w-full mt-auto pt-8`]}>
-        <Button
-          fullWidth
-          disabled={!celebrityId.value}
-          onClick={() => setStep('gender')}
-        >
+        <Button fullWidth disabled={!celebrityId.value} onClick={onClickNext}>
           다음으로
         </Button>
       </div>
-    </Funnel.Step>
+    </>
   );
 }
 

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -10,8 +10,17 @@ function CreateOutfitPostFunnel() {
   return (
     <div css={[tw`flex flex-col items-center flex-1 p-4 pb-6`]}>
       <Funnel>
-        <CreateOutfitPostCelebrityStep />
-        <CreateOutfitPostGenderStep />
+        <Funnel.Step name="celebrity">
+          <CreateOutfitPostCelebrityStep
+            onClickNext={() => setStep('gender')}
+          />
+        </Funnel.Step>
+        <Funnel.Step name="gender">
+          <CreateOutfitPostGenderStep
+            onClickPrevious={() => setStep('celebrity')}
+            onClickNext={() => setStep('title')}
+          />
+        </Funnel.Step>
         <Funnel.Step name="title">
           <CreateOutfitPostTitleStep
             onClickPrevious={() => setStep('gender')}

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -1,16 +1,23 @@
 import tw from 'twin.macro';
-import useCreateOutfitPostPageContext from '../useCreateOutfitPostPageContext';
+import useCreateOutfitPostFunnel from '../useCreateOutfitPostFunnel';
 import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep';
 import CreateOutfitPostGenderStep from './CreateOutfitPostGenderStep';
+import CreateOutfitPostTitleStep from './CreateOutfitPostTitleStep';
 
 function CreateOutfitPostFunnel() {
-  const { Funnel } = useCreateOutfitPostPageContext();
+  const { Funnel, setStep } = useCreateOutfitPostFunnel();
 
   return (
     <div css={[tw`flex flex-col items-center flex-1 p-4 pb-6`]}>
       <Funnel>
         <CreateOutfitPostCelebrityStep />
         <CreateOutfitPostGenderStep />
+        <Funnel.Step name="title">
+          <CreateOutfitPostTitleStep
+            onClickPrevious={() => setStep('gender')}
+            onClickNext={() => setStep('outfitPostImage')}
+          />
+        </Funnel.Step>
       </Funnel>
     </div>
   );

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/CreateOutfitPostGenderStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/CreateOutfitPostGenderStep.tsx
@@ -26,7 +26,7 @@ function CreateOutfitPostGenderStep() {
         <Button
           fullWidth
           disabled={!gender.value}
-          onClick={() => setStep('outfitPostImage')}
+          onClick={() => setStep('title')}
         >
           다음으로
         </Button>

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/CreateOutfitPostGenderStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostGenderStep/CreateOutfitPostGenderStep.tsx
@@ -5,11 +5,19 @@ import CreateOutfitPostProgress from '../CreateOutfitPostProgress';
 import CreateOutfitPostTitle from '../CreateOutfitPostTitle';
 import OutfitPostGenderRadioGroup from './OutfitPostGenderRadioGroup';
 
-function CreateOutfitPostGenderStep() {
-  const { Funnel, setStep, gender } = useCreateOutfitPostPageContext();
+interface CreateOutfitPostGenderStepProps {
+  onClickPrevious: () => void;
+  onClickNext: () => void;
+}
+
+function CreateOutfitPostGenderStep({
+  onClickPrevious,
+  onClickNext,
+}: CreateOutfitPostGenderStepProps) {
+  const { gender } = useCreateOutfitPostPageContext();
 
   return (
-    <Funnel.Step name="gender">
+    <>
       <CreateOutfitPostProgress stepNumber={2} />
       <CreateOutfitPostTitle>
         코디에 맞는 성별을
@@ -20,18 +28,14 @@ function CreateOutfitPostGenderStep() {
         onChange={gender.onChange}
       />
       <div css={[tw`sticky bottom-0 flex gap-x-6 w-full mt-auto`]}>
-        <Button fullWidth color="gray" onClick={() => setStep('celebrity')}>
+        <Button fullWidth color="gray" onClick={onClickPrevious}>
           이전으로
         </Button>
-        <Button
-          fullWidth
-          disabled={!gender.value}
-          onClick={() => setStep('title')}
-        >
+        <Button fullWidth disabled={!gender.value} onClick={onClickNext}>
           다음으로
         </Button>
       </div>
-    </Funnel.Step>
+    </>
   );
 }
 

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostTitleStep/CreateOutfitPostTitleStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostTitleStep/CreateOutfitPostTitleStep.tsx
@@ -1,0 +1,56 @@
+import tw from 'twin.macro';
+import Button from '../../../../components/atoms/Button';
+import TextField from '../../../../components/atoms/TextField';
+import useCreateOutfitPostPageContext from '../../useCreateOutfitPostPageContext';
+import CreateOutfitPostProgress from '../CreateOutfitPostProgress';
+import CreateOutfitPostTitle from '../CreateOutfitPostTitle';
+
+interface CreateOutfitPostTitleStepProps {
+  onClickPrevious: () => void;
+  onClickNext: () => void;
+}
+
+function CreateOutfitPostTitleStep({
+  onClickPrevious,
+  onClickNext,
+}: CreateOutfitPostTitleStepProps) {
+  const { title, trigger, errors } = useCreateOutfitPostPageContext();
+
+  const handleClickNextButton = async () => {
+    const isValid = await trigger('title');
+    if (!isValid) {
+      return;
+    }
+    onClickNext();
+  };
+
+  return (
+    <>
+      <CreateOutfitPostProgress stepNumber={3} />
+      <CreateOutfitPostTitle>코디 제목을 입력해 주세요.</CreateOutfitPostTitle>
+      <TextField
+        value={title.value}
+        onChange={title.onChange}
+        label="코디 제목"
+        css={[tw`max-w-[360px]`]}
+      />
+      {errors.title && (
+        <p css={[tw`text-red-500 mt-2`]}>{errors.title.message}</p>
+      )}
+      <div css={[tw`sticky bottom-0 flex gap-x-6 w-full mt-auto`]}>
+        <Button fullWidth color="gray" onClick={onClickPrevious}>
+          이전으로
+        </Button>
+        <Button
+          fullWidth
+          disabled={!title.value}
+          onClick={handleClickNextButton}
+        >
+          다음으로
+        </Button>
+      </div>
+    </>
+  );
+}
+
+export default CreateOutfitPostTitleStep;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostTitleStep/index.ts
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostTitleStep/index.ts
@@ -1,0 +1,3 @@
+import CreateOutfitPostTitleStep from './CreateOutfitPostTitleStep';
+
+export default CreateOutfitPostTitleStep;

--- a/src/pages/CreateOutfitPostPage/useCreateOutfitPostForm.ts
+++ b/src/pages/CreateOutfitPostPage/useCreateOutfitPostForm.ts
@@ -13,7 +13,7 @@ const schema = z.object({
     .string()
     .min(1, { message: '코디 제목을 입력해 주세요.' })
     .min(4, { message: '코디 제목은 4자 이상이어야 합니다.' })
-    .max(12, { message: '코디 제목은 20자 이하여야 합니다.' }),
+    .max(20, { message: '코디 제목은 20자 이하여야 합니다.' }),
   image: fileSchema({
     requiredMessage: '코디 이미지를 업로드해 주세요.',
   }),

--- a/src/pages/CreateOutfitPostPage/useCreateOutfitPostForm.ts
+++ b/src/pages/CreateOutfitPostPage/useCreateOutfitPostForm.ts
@@ -27,6 +27,7 @@ const useCreateOutfitPostForm = () => {
   const {
     control,
     handleSubmit,
+    trigger,
     resetField,
     formState: { errors },
   } = useForm<CreateOutfitPostRequest['payload']>({
@@ -63,6 +64,7 @@ const useCreateOutfitPostForm = () => {
 
   return {
     handleSubmit,
+    trigger,
     resetField,
     errors,
     celebrityId,


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 코디 생성 페이지 Funnel에서 코디 제목 입력 스텝 컴포넌트를 구현 했습니다.

### 상세 작업 내역
- 성별 선택 스텝에서 다음으로 버튼을 눌렀을 때 코디 이미지 선택 스텝으로 넘어가는 버그 수정
- Step 컴포넌트 내부에서 ```Funnel.Step``` 컴포넌트를 사용할 경우 Context값이 변경될 때 컴포넌트가 리렌더링이 아닌 재생성 되는 성능 문제를 개선하기 위해 ```Funnel.Step``` 컴포넌트를 부모 컴포넌트로 분리
- 코디 제목 입력 스텝 구현

### 📸 스크린샷
- 유효성 검사 성공

![image](https://github.com/user-attachments/assets/899f3911-2760-4624-a5df-af4b704c2350)


- 유효성 검사 실패

![image](https://github.com/user-attachments/assets/14022ed0-c530-4bf7-9392-843447ad1050)


closed #이슈번호
