### PR TITLE
feat: 코디 생성 페이지 - 코디 사진 선택 스텝 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "path-browserify": "^1.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-easy-crop": "^5.0.8",
     "react-error-boundary": "^4.0.13",
     "react-hook-form": "^7.52.2",
     "react-intersection-observer": "^9.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-easy-crop:
+        specifier: ^5.0.8
+        version: 5.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-error-boundary:
         specifier: ^4.0.13
         version: 4.0.13(react@18.3.1)
@@ -3554,6 +3557,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -3945,6 +3951,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-easy-crop@5.0.8:
+    resolution: {integrity: sha512-KjulxXhR5iM7+ATN2sGCum/IyDxGw7xT0dFoGcqUP+ysaPU5Ka7gnrDa2tUHFHUoMNyPrVZ05QA+uvMgC5ym/g==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-element-to-jsx-string@15.0.0:
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
@@ -8668,6 +8680,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  normalize-wheel@1.0.1: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -9005,6 +9019,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-easy-crop@5.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
 
   react-element-to-jsx-string@15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/components/atoms/ImageUploader/ImageUploader.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploader.tsx
@@ -14,10 +14,20 @@ import ImageUploaderCropper from './ImageUploaderCropper';
 
 interface ImageUploaderProps extends ComponentPropsWithoutRef<'label'> {
   image: File | undefined;
+
   setImage: (image: File) => void;
+
+  /**
+   * 업로더의 크기를 나타내는 단위 입니다.
+   * 'px' 단위로 값이 적용 됩니다.
+   */
   size?: number;
 }
 
+/**
+ * 이미지를 업로드하고 미리보기 이미지를 확인할 수 있습니다.
+ * 이미지를 업로드 하면 크롭 기능을 통해 이미지를 정방형으로 자를 수 있습니다.
+ */
 function ImageUploader({
   image,
   setImage,

--- a/src/components/atoms/ImageUploader/ImageUploader.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploader.tsx
@@ -47,7 +47,7 @@ function ImageUploader({
   }, [image, croppedImageUrl]);
 
   return (
-    <>
+    <div css={[tw`flex flex-col items-center`]}>
       <label
         htmlFor={fileInputId}
         css={[
@@ -94,7 +94,7 @@ function ImageUploader({
           setShowCropper={setShowCropper}
         />
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/components/atoms/ImageUploader/ImageUploader.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploader.tsx
@@ -1,0 +1,101 @@
+import {
+  ChangeEvent,
+  ComponentPropsWithoutRef,
+  useEffect,
+  useId,
+  useState,
+} from 'react';
+
+import AddPhotoAlternateOutlinedIcon from '@mui/icons-material/AddPhotoAlternateOutlined';
+import FullscreenRoundedIcon from '@mui/icons-material/FullscreenRounded';
+import tw from 'twin.macro';
+import Button from '../Button';
+import ImageUploaderCropper from './ImageUploaderCropper';
+
+interface ImageUploaderProps extends ComponentPropsWithoutRef<'label'> {
+  image: File | undefined;
+  onChange: () => void;
+  size?: number;
+}
+
+function ImageUploader({
+  image,
+  onChange,
+  size = 320,
+  ...props
+}: ImageUploaderProps) {
+  const fileInputId = useId();
+
+  const [originalImageUrl, setOriginalImageUrl] = useState<string>();
+  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
+  const [showCropper, setShowCropper] = useState(false);
+
+  const handleChangeFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const fileList = event.target.files;
+    if (!fileList || fileList.length < 1) {
+      return;
+    }
+    setOriginalImageUrl(URL.createObjectURL(fileList[0]));
+    setShowCropper(true);
+  };
+
+  useEffect(() => {
+    if (!image || !!croppedImageUrl) {
+      return;
+    }
+    setCroppedImageUrl(URL.createObjectURL(image));
+  }, [image, croppedImageUrl]);
+
+  return (
+    <>
+      <label
+        htmlFor={fileInputId}
+        css={[
+          tw`flex-center flex-col gap-y-4 rounded-lg border-solid border-4 border-gray-300 text-gray-300 cursor-pointer`,
+          { width: size, height: size },
+        ]}
+        {...props}
+      >
+        <input
+          id={fileInputId}
+          type="file"
+          onChange={handleChangeFile}
+          css={[tw`hidden`]}
+        />
+        {croppedImageUrl ? (
+          <img
+            src={croppedImageUrl}
+            alt="코디 사진"
+            css={[tw`w-full h-full rounded-[4px]`]}
+          />
+        ) : (
+          <>
+            <AddPhotoAlternateOutlinedIcon css={[tw`text-7xl`]} />
+            <span css={[tw`text-2xl font-bold`]}>사진 업로드</span>
+          </>
+        )}
+      </label>
+      {!!croppedImageUrl && (
+        <Button
+          onClick={() => setShowCropper(true)}
+          color="indigo"
+          css={[tw`mt-3 gap-1`]}
+        >
+          <FullscreenRoundedIcon fontSize="small" />
+          범위 재설정
+        </Button>
+      )}
+
+      {showCropper && (
+        <ImageUploaderCropper
+          originalImageUrl={originalImageUrl}
+          setCroppedImage={onChange}
+          setCroppedImageUrl={setCroppedImageUrl}
+          setShowCropper={setShowCropper}
+        />
+      )}
+    </>
+  );
+}
+
+export default ImageUploader;

--- a/src/components/atoms/ImageUploader/ImageUploader.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploader.tsx
@@ -14,13 +14,13 @@ import ImageUploaderCropper from './ImageUploaderCropper';
 
 interface ImageUploaderProps extends ComponentPropsWithoutRef<'label'> {
   image: File | undefined;
-  onChange: () => void;
+  setImage: (image: File) => void;
   size?: number;
 }
 
 function ImageUploader({
   image,
-  onChange,
+  setImage,
   size = 320,
   ...props
 }: ImageUploaderProps) {
@@ -89,7 +89,7 @@ function ImageUploader({
       {showCropper && (
         <ImageUploaderCropper
           originalImageUrl={originalImageUrl}
-          setCroppedImage={onChange}
+          setCroppedImage={setImage}
           setCroppedImageUrl={setCroppedImageUrl}
           setShowCropper={setShowCropper}
         />

--- a/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
@@ -11,7 +11,7 @@ import getCroppedImg from './helpers';
 interface ImageUploaderCropperProps {
   originalImageUrl: string | undefined;
   setCroppedImageUrl: Dispatch<SetStateAction<string | undefined>>;
-  setCroppedImage: Dispatch<SetStateAction<File | undefined>>;
+  setCroppedImage: (image: File) => void;
   setShowCropper: Dispatch<SetStateAction<boolean>>;
 }
 

--- a/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
@@ -1,0 +1,88 @@
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { Dispatch, SetStateAction, useState } from 'react';
+import { createPortal } from 'react-dom';
+import Cropper, { Area, Point } from 'react-easy-crop';
+import tw from 'twin.macro';
+import { blobToFile } from '../../../utils/file';
+import IconButton from '../IconButton';
+import getCroppedImg from './helpers';
+
+interface ImageUploaderCropperProps {
+  originalImageUrl: string | undefined;
+  setCroppedImageUrl: Dispatch<SetStateAction<string | undefined>>;
+  setCroppedImage: Dispatch<SetStateAction<File | undefined>>;
+  setShowCropper: Dispatch<SetStateAction<boolean>>;
+}
+
+function ImageUploaderCropper({
+  originalImageUrl,
+  setCroppedImageUrl,
+  setCroppedImage,
+  setShowCropper,
+}: ImageUploaderCropperProps) {
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>();
+
+  const onCropComplete = (_: Area, areaPixels: Area) => {
+    setCroppedAreaPixels(areaPixels);
+  };
+
+  const handleClickSaveButton = async () => {
+    if (!originalImageUrl || !croppedAreaPixels) {
+      return;
+    }
+
+    const image = await getCroppedImg(originalImageUrl, croppedAreaPixels);
+
+    if (!image) {
+      throw Error('이미지 Crop 도중 오류가 발생 했습니다.');
+    }
+
+    setCroppedImage(blobToFile(image));
+    setCroppedImageUrl(URL.createObjectURL(image));
+    setShowCropper(false);
+  };
+
+  return createPortal(
+    <div css={[tw`z-50 absolute top-0 left-0 w-full h-full`]}>
+      <Cropper
+        image={originalImageUrl}
+        crop={crop}
+        zoom={zoom}
+        aspect={1}
+        onCropChange={setCrop}
+        onCropComplete={onCropComplete}
+        onZoomChange={setZoom}
+      />
+      <div
+        css={[
+          tw`absolute bottom-0 left-0 flex-y-center justify-between gap-4 w-full p-2 bg-white`,
+        ]}
+      >
+        <IconButton
+          icon={<CloseRoundedIcon />}
+          onClick={() => setShowCropper(false)}
+        />
+        <input
+          type="range"
+          value={zoom}
+          min="1"
+          max="3"
+          step="0.1"
+          onChange={(e) => setZoom(Number(e.target.value))}
+          css={[tw`flex-1`]}
+        />
+        <IconButton
+          icon={<CheckRoundedIcon />}
+          onClick={handleClickSaveButton}
+          disabled={!originalImageUrl || !croppedAreaPixels}
+        />
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default ImageUploaderCropper;

--- a/src/components/atoms/ImageUploader/helpers.ts
+++ b/src/components/atoms/ImageUploader/helpers.ts
@@ -1,0 +1,69 @@
+import { Area } from 'react-easy-crop';
+
+const createImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (error) => reject(error));
+    image.src = url;
+  });
+
+const getCroppedImg = async (
+  imageSrc: string,
+  pixelCrop: Area,
+  flip = { horizontal: false, vertical: false }
+): Promise<Blob | null> => {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    return null;
+  }
+
+  // set canvas size to match the bounding box
+  canvas.width = image.width;
+  canvas.height = image.height;
+
+  // translate canvas context to a central location to allow rotating and flipping around the center
+  ctx.translate(image.width / 2, image.height / 2);
+  ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1);
+  ctx.translate(-image.width / 2, -image.height / 2);
+
+  // draw rotated image
+  ctx.drawImage(image, 0, 0);
+
+  const croppedCanvas = document.createElement('canvas');
+
+  const croppedCtx = croppedCanvas.getContext('2d');
+
+  if (!croppedCtx) {
+    return null;
+  }
+
+  // Set the size of the cropped canvas
+  croppedCanvas.width = pixelCrop.width;
+  croppedCanvas.height = pixelCrop.height;
+
+  // Draw the cropped image onto the new canvas
+  croppedCtx.drawImage(
+    canvas,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height
+  );
+
+  // As a blob
+  return new Promise((resolve) => {
+    croppedCanvas.toBlob((file) => {
+      resolve(file);
+    }, 'image/jpeg');
+  });
+};
+
+export default getCroppedImg;

--- a/src/components/atoms/ImageUploader/index.stories.tsx
+++ b/src/components/atoms/ImageUploader/index.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useState } from 'react';
+import ImageUploader from './index';
+
+const meta = {
+  component: ImageUploader,
+  argTypes: {
+    image: {
+      table: {
+        type: {
+          summary: 'File',
+        },
+      },
+    },
+  }
+} satisfies Meta<typeof ImageUploader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    image: undefined,
+    setImage: () => {},
+  },
+  render: function Render() {
+    const [image, setImage] = useState<File>();
+    return <ImageUploader image={image} setImage={setImage} />;
+  },
+};

--- a/src/components/atoms/ImageUploader/index.ts
+++ b/src/components/atoms/ImageUploader/index.ts
@@ -1,0 +1,3 @@
+import ImageUploader from './ImageUploader';
+
+export default ImageUploader;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostFunnel.tsx
@@ -2,6 +2,7 @@ import tw from 'twin.macro';
 import useCreateOutfitPostFunnel from '../useCreateOutfitPostFunnel';
 import CreateOutfitPostCelebrityStep from './CreateOutfitPostCelebrityStep';
 import CreateOutfitPostGenderStep from './CreateOutfitPostGenderStep';
+import CreateOutfitPostImageStep from './CreateOutfitPostImageStep';
 import CreateOutfitPostTitleStep from './CreateOutfitPostTitleStep';
 
 function CreateOutfitPostFunnel() {
@@ -25,6 +26,12 @@ function CreateOutfitPostFunnel() {
           <CreateOutfitPostTitleStep
             onClickPrevious={() => setStep('gender')}
             onClickNext={() => setStep('outfitPostImage')}
+          />
+        </Funnel.Step>
+        <Funnel.Step name="outfitPostImage">
+          <CreateOutfitPostImageStep
+            onClickPrevious={() => setStep('title')}
+            onClickNext={() => setStep('outfitItems')}
           />
         </Funnel.Step>
       </Funnel>

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/CreateOutfitPostImageStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/CreateOutfitPostImageStep.tsx
@@ -1,0 +1,51 @@
+import tw from 'twin.macro';
+import Button from '../../../../components/atoms/Button';
+import ImageUploader from '../../../../components/atoms/ImageUploader';
+import useCreateOutfitPostPageContext from '../../useCreateOutfitPostPageContext';
+import CreateOutfitPostProgress from '../CreateOutfitPostProgress';
+import CreateOutfitPostTitle from '../CreateOutfitPostTitle';
+
+interface CreateOutfitPostImageStepProps {
+  onClickPrevious: () => void;
+  onClickNext: () => void;
+}
+
+function CreateOutfitPostImageStep({
+  onClickPrevious,
+  onClickNext,
+}: CreateOutfitPostImageStepProps) {
+  const { image, trigger, errors } = useCreateOutfitPostPageContext();
+
+  const handleClickNextButton = async () => {
+    const isValid = await trigger('image');
+    if (!isValid) {
+      return;
+    }
+    onClickNext();
+  };
+
+  return (
+    <>
+      <CreateOutfitPostProgress stepNumber={4} />
+      <CreateOutfitPostTitle>코디 사진을 선택해 주세요.</CreateOutfitPostTitle>
+      <ImageUploader image={image.value} onChange={image.onChange} />
+      {errors.image && (
+        <p css={[tw`text-red-500 mt-2`]}>{errors.image.message}</p>
+      )}
+      <div css={[tw`sticky bottom-0 flex gap-x-6 w-full mt-auto`]}>
+        <Button fullWidth color="gray" onClick={onClickPrevious}>
+          이전으로
+        </Button>
+        <Button
+          fullWidth
+          disabled={!image.value}
+          onClick={handleClickNextButton}
+        >
+          다음으로
+        </Button>
+      </div>
+    </>
+  );
+}
+
+export default CreateOutfitPostImageStep;

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/CreateOutfitPostImageStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/CreateOutfitPostImageStep.tsx
@@ -28,7 +28,7 @@ function CreateOutfitPostImageStep({
     <>
       <CreateOutfitPostProgress stepNumber={4} />
       <CreateOutfitPostTitle>코디 사진을 선택해 주세요.</CreateOutfitPostTitle>
-      <ImageUploader image={image.value} onChange={image.onChange} />
+      <ImageUploader image={image.value} setImage={image.onChange} />
       {errors.image && (
         <p css={[tw`text-red-500 mt-2`]}>{errors.image.message}</p>
       )}

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/index.ts
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/index.ts
@@ -1,0 +1,3 @@
+import CreateOutfitPostImageStep from './CreateOutfitPostImageStep';
+
+export default CreateOutfitPostImageStep;

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,8 @@
+export const blobToFile = (theBlob: Blob): File => {
+  const extensionName = theBlob.type.split('/')[1];
+
+  return new File([theBlob], `${crypto.randomUUID()}.${extensionName}`, {
+    lastModified: new Date().getTime(),
+    type: theBlob.type,
+  });
+};


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 코디 생성 페이지 Funnel에서 코디 사진 선택 스텝 컴포넌트를 구현 했습니다.

### 작업 상세 내용
- ImageUpload 컴포넌트 구현(react-easy-crop 라이브러리 사용)
- 코디 사진 선택 스텝 컴포넌트 구현

### 📸 스크린샷
- 사진 업로드 전

![image](https://github.com/user-attachments/assets/a540b368-03e1-44ad-9454-5f5b9a378d93)

- 사진 크롭 화면

![image](https://github.com/user-attachments/assets/1b525516-b292-4c6f-9967-b4bf62c163b6)

- 사진 업로드 이후 화면

![image](https://github.com/user-attachments/assets/f1190e7d-c8b8-4a64-9261-ab4f2d93f2ad)

closed #83
