### PR TITLE
fix: ImageUploader 사진 선택 버그 수정

### DIFF
--- a/src/components/atoms/ImageUploader/ImageUploader.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploader.tsx
@@ -1,10 +1,4 @@
-import {
-  ChangeEvent,
-  ComponentPropsWithoutRef,
-  useEffect,
-  useId,
-  useState,
-} from 'react';
+import { ChangeEvent, ComponentPropsWithoutRef, useId, useState } from 'react';
 
 import AddPhotoAlternateOutlinedIcon from '@mui/icons-material/AddPhotoAlternateOutlined';
 import FullscreenRoundedIcon from '@mui/icons-material/FullscreenRounded';
@@ -13,9 +7,25 @@ import Button from '../Button';
 import ImageUploaderCropper from './ImageUploaderCropper';
 
 interface ImageUploaderProps extends ComponentPropsWithoutRef<'label'> {
+  /**
+   * 크롭된 이미지 파일 입니다.
+   */
   image: File | undefined;
-
   setImage: (image: File) => void;
+
+  /**
+   * 크롭시 필요한 원본 이미지의 미리보기 URL 입니다.
+   * 상태 유지가 필요한 경우를 위해 prop으로 상태를 관리하고 있습니다.
+   */
+  originalImageUrl: string | undefined;
+  setOriginalImageUrl: (url: string) => void;
+
+  /**
+   * 크롭된 이미지의 미리보기 URL 입니다.
+   * 상태 유지가 필요한 경우를 위해 prop으로 상태를 관리하고 있습니다.
+   */
+  croppedImageUrl: string | undefined;
+  setCroppedImageUrl: (url: string) => void;
 
   /**
    * 업로더의 크기를 나타내는 단위 입니다.
@@ -31,13 +41,14 @@ interface ImageUploaderProps extends ComponentPropsWithoutRef<'label'> {
 function ImageUploader({
   image,
   setImage,
+  originalImageUrl,
+  setOriginalImageUrl,
+  croppedImageUrl,
+  setCroppedImageUrl,
   size = 320,
   ...props
 }: ImageUploaderProps) {
   const fileInputId = useId();
-
-  const [originalImageUrl, setOriginalImageUrl] = useState<string>();
-  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
   const [showCropper, setShowCropper] = useState(false);
 
   const handleChangeFile = (event: ChangeEvent<HTMLInputElement>) => {
@@ -48,13 +59,6 @@ function ImageUploader({
     setOriginalImageUrl(URL.createObjectURL(fileList[0]));
     setShowCropper(true);
   };
-
-  useEffect(() => {
-    if (!image || !!croppedImageUrl) {
-      return;
-    }
-    setCroppedImageUrl(URL.createObjectURL(image));
-  }, [image, croppedImageUrl]);
 
   return (
     <div css={[tw`flex flex-col items-center`]}>

--- a/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
@@ -1,6 +1,6 @@
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import Cropper, { Area, Point } from 'react-easy-crop';
 import tw from 'twin.macro';
@@ -10,9 +10,9 @@ import getCroppedImg from './helpers';
 
 interface ImageUploaderCropperProps {
   originalImageUrl: string | undefined;
-  setCroppedImageUrl: Dispatch<SetStateAction<string | undefined>>;
+  setCroppedImageUrl: (url: string) => void;
   setCroppedImage: (image: File) => void;
-  setShowCropper: Dispatch<SetStateAction<boolean>>;
+  setShowCropper: (isShow: boolean) => void;
 }
 
 function ImageUploaderCropper({

--- a/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
+++ b/src/components/atoms/ImageUploader/ImageUploaderCropper.tsx
@@ -1,5 +1,4 @@
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
-import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import Cropper, { Area, Point } from 'react-easy-crop';
@@ -58,13 +57,9 @@ function ImageUploaderCropper({
       />
       <div
         css={[
-          tw`absolute bottom-0 left-0 flex-y-center justify-between gap-4 w-full p-2 bg-white`,
+          tw`absolute bottom-0 left-0 flex-y-center justify-between gap-2 w-full p-2 pl-4 bg-white`,
         ]}
       >
-        <IconButton
-          icon={<CloseRoundedIcon />}
-          onClick={() => setShowCropper(false)}
-        />
         <input
           type="range"
           value={zoom}

--- a/src/components/atoms/ImageUploader/index.stories.tsx
+++ b/src/components/atoms/ImageUploader/index.stories.tsx
@@ -13,6 +13,20 @@ const meta = {
         },
       },
     },
+    originalImageUrl: {
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+    croppedImageUrl: {
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
   },
 } satisfies Meta<typeof ImageUploader>;
 
@@ -24,9 +38,25 @@ export const Default: Story = {
   args: {
     image: undefined,
     setImage: () => {},
+    originalImageUrl: undefined,
+    setOriginalImageUrl: () => {},
+    croppedImageUrl: undefined,
+    setCroppedImageUrl: () => {},
   },
   render: function Render() {
     const [image, setImage] = useState<File>();
-    return <ImageUploader image={image} setImage={setImage} />;
+    const [originalImageUrl, setOriginalImageUrl] = useState<string>();
+    const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
+
+    return (
+      <ImageUploader
+        image={image}
+        setImage={setImage}
+        originalImageUrl={originalImageUrl}
+        setOriginalImageUrl={setOriginalImageUrl}
+        croppedImageUrl={croppedImageUrl}
+        setCroppedImageUrl={setCroppedImageUrl}
+      />
+    );
   },
 };

--- a/src/pages/CreateOutfitPostPage/CreateOutfitPostPageProvider.tsx
+++ b/src/pages/CreateOutfitPostPage/CreateOutfitPostPageProvider.tsx
@@ -1,9 +1,21 @@
-import { createContext, ReactNode } from 'react';
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useMemo,
+  useState,
+} from 'react';
 import useCreateOutfitPostForm from './useCreateOutfitPostForm';
 
 type CreateOutfitPostPageContextType = ReturnType<
   typeof useCreateOutfitPostForm
->;
+> & {
+  originalImageUrl: string | undefined;
+  setOriginalImageUrl: Dispatch<SetStateAction<string | undefined>>;
+  croppedImageUrl: string | undefined;
+  setCroppedImageUrl: Dispatch<SetStateAction<string | undefined>>;
+};
 
 export const CreateOutfitPostPageContext =
   createContext<CreateOutfitPostPageContextType | null>(null);
@@ -15,8 +27,29 @@ interface CreateOutfitPostPageProviderProps {
 export function CreateOutfitPostPageProvider({
   children,
 }: CreateOutfitPostPageProviderProps) {
+  const formController = useCreateOutfitPostForm();
+  const [originalImageUrl, setOriginalImageUrl] = useState<string>();
+  const [croppedImageUrl, setCroppedImageUrl] = useState<string>();
+
+  const value = useMemo(
+    () => ({
+      ...formController,
+      originalImageUrl,
+      setOriginalImageUrl,
+      croppedImageUrl,
+      setCroppedImageUrl,
+    }),
+    [
+      formController,
+      originalImageUrl,
+      setOriginalImageUrl,
+      croppedImageUrl,
+      setCroppedImageUrl,
+    ]
+  );
+
   return (
-    <CreateOutfitPostPageContext.Provider value={useCreateOutfitPostForm()}>
+    <CreateOutfitPostPageContext.Provider value={value}>
       {children}
     </CreateOutfitPostPageContext.Provider>
   );

--- a/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/CreateOutfitPostImageStep.tsx
+++ b/src/pages/CreateOutfitPostPage/components/CreateOutfitPostImageStep/CreateOutfitPostImageStep.tsx
@@ -14,7 +14,15 @@ function CreateOutfitPostImageStep({
   onClickPrevious,
   onClickNext,
 }: CreateOutfitPostImageStepProps) {
-  const { image, trigger, errors } = useCreateOutfitPostPageContext();
+  const {
+    image,
+    trigger,
+    errors,
+    originalImageUrl,
+    setOriginalImageUrl,
+    croppedImageUrl,
+    setCroppedImageUrl,
+  } = useCreateOutfitPostPageContext();
 
   const handleClickNextButton = async () => {
     const isValid = await trigger('image');
@@ -28,7 +36,14 @@ function CreateOutfitPostImageStep({
     <>
       <CreateOutfitPostProgress stepNumber={4} />
       <CreateOutfitPostTitle>코디 사진을 선택해 주세요.</CreateOutfitPostTitle>
-      <ImageUploader image={image.value} setImage={image.onChange} />
+      <ImageUploader
+        image={image.value}
+        setImage={image.onChange}
+        originalImageUrl={originalImageUrl}
+        setOriginalImageUrl={setOriginalImageUrl}
+        croppedImageUrl={croppedImageUrl}
+        setCroppedImageUrl={setCroppedImageUrl}
+      />
       {errors.image && (
         <p css={[tw`text-red-500 mt-2`]}>{errors.image.message}</p>
       )}


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- ImageUploader의 미리보기 image url을 상태로 관리해 페이지 이동시 재설정 안되는 버그 수정
- 크롭 닫기버튼 제거를 통해 동일 사진 재선택 안되는 버그 수정

closed #85
